### PR TITLE
Bump Rust version to 1.87 for moq-rs builds

### DIFF
--- a/builds/moq-rs/Dockerfile.client
+++ b/builds/moq-rs/Dockerfile.client
@@ -11,7 +11,7 @@
 # If your network uses TLS inspection, place your CA certificate at
 # builds/moq-rs/extra-ca.pem and it will be trusted during the build.
 
-FROM rust:1.82-bookworm AS builder
+FROM rust:1.87-bookworm AS builder
 
 # Support for networks with TLS inspection - trust additional CA if provided
 RUN --mount=type=secret,id=ca_cert,target=/tmp/extra-ca.pem \

--- a/builds/moq-rs/Dockerfile.relay
+++ b/builds/moq-rs/Dockerfile.relay
@@ -11,7 +11,7 @@
 # If your network uses TLS inspection, place your CA certificate at
 # builds/moq-rs/extra-ca.pem and it will be trusted during the build.
 
-FROM rust:1.82-bookworm AS builder
+FROM rust:1.87-bookworm AS builder
 
 # Support for networks with TLS inspection - trust additional CA if provided
 RUN --mount=type=secret,id=ca_cert,target=/tmp/extra-ca.pem \


### PR DESCRIPTION
## Summary

- Updates moq-rs Dockerfiles to use Rust 1.87 instead of 1.82
- Fixes build failure caused by `unsigned_is_multiple_of` being unstable in Rust 1.82

## Details

The moq-rs crate uses the `.is_multiple_of()` method on unsigned integers in `moq-transport/src/coding/kvp.rs`. This feature was stabilized in Rust 1.87.0 (rust-lang/rust#128101).

Building with Rust 1.82 fails with:
```
error[E0658]: use of unstable library feature 'unsigned_is_multiple_of'
```

## Testing

Verified that `make build-moq-rs` completes successfully after this change.