### PR TITLE
Fix docker tests for moxygen relay

### DIFF
--- a/adapters/moxygen/Dockerfile
+++ b/adapters/moxygen/Dockerfile
@@ -16,6 +16,19 @@
 
 FROM ghcr.io/facebookexperimental/moqrelay:latest-amd64
 
+# Fix for running as non-root user (e.g., via docker-compose user: directive)
+#
+# Facebook's getdeps.py uses different scratch paths based on UID:
+#   - root (UID 0):  /tmp/fbcode_builder_getdeps-...-root/
+#   - non-root:      /tmp/fbcode_builder_getdeps-.../
+#
+# Since the upstream image was built as root, binaries are at the -root path.
+# Create a symlink so non-root users can find them via getdeps.py.
+RUN ROOT_DIR=$(ls -d /tmp/fbcode_builder_getdeps-*-root 2>/dev/null | head -1) && \
+    if [ -n "$ROOT_DIR" ]; then \
+        ln -s "$ROOT_DIR" "${ROOT_DIR%-root}"; \
+    fi
+
 # Map our /certs convention to moxygen's expected env vars
 # Upstream default port is 4433, we use 4443 for consistency with other implementations
 ENV MOQ_PORT=4443
@@ -26,6 +39,12 @@ ENV MOQ_ENDPOINT=/
 ENV MOQ_LOG_LEVEL=DBG2
 
 EXPOSE 4443/udp
+
+# Custom healthcheck since the upstream image doesn't have ss/netstat installed.
+# The relay binds to IPv6, so we check /proc/net/udp6 for port 4443 (0x115B in hex).
+# This overrides the healthcheck from docker-compose.test.yml for this image.
+HEALTHCHECK --interval=2s --timeout=5s --start-period=5s --retries=10 \
+    CMD grep -qi ":115B" /proc/net/udp6 || grep -qi ":115B" /proc/net/udp || exit 1
 
 # The upstream image's CMD uses these environment variables to start moqrelayserver
 # No custom entrypoint needed - the env var overrides are sufficient

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -26,8 +26,11 @@ services:
       - MOQT_ROLE=relay
       - MOQT_PORT=4443
     healthcheck:
-      # Use ss with fallback, and support configurable port via MOQT_PORT
-      test: ["CMD", "sh", "-c", "ss -uln 2>/dev/null | grep -q ':${MOQT_PORT:-4443}' || netstat -uln 2>/dev/null | grep -q ':${MOQT_PORT:-4443}' || exit 1"]
+      # Check if relay is listening on UDP port. Try multiple methods for compatibility:
+      # 1. ss (iproute2) - most common on modern systems
+      # 2. netstat (net-tools) - fallback for older systems
+      # 3. /proc/net/udp{,6} - works without any tools, converts port to hex
+      test: ["CMD", "sh", "-c", "PORT=${MOQT_PORT:-4443}; ss -uln 2>/dev/null | grep -q \":$PORT\" || netstat -uln 2>/dev/null | grep -q \":$PORT\" || { HEX=$(printf '%X' $PORT); grep -qi \":$HEX\" /proc/net/udp 2>/dev/null || grep -qi \":$HEX\" /proc/net/udp6 2>/dev/null; } || exit 1"]
       interval: 2s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
## Summary

- Fix binary not found error when running moxygen as non-root user
- Add fallback healthcheck method for images without ss/netstat

## Details

Two issues were preventing moxygen from working in docker-compose tests:

### 1. Binary not found when running as non-root user

Facebook's `getdeps.py` uses different scratch paths based on UID:
- Root (UID 0): `/tmp/fbcode_builder_getdeps-...-root/`
- Non-root: `/tmp/fbcode_builder_getdeps-.../`

Since the upstream image was built as root but docker-compose runs containers as non-root (user 1000), the paths didn't match and the relay binary couldn't be found.

**Fix:** Added a `RUN` command in `adapters/moxygen/Dockerfile` that creates a symlink from the non-root path to the root path.

### 2. Healthcheck failing due to missing tools

The `docker-compose.test.yml` healthcheck uses `ss` or `netstat`, neither of which are installed in the moxygen image.

**Fix:** Updated the healthcheck to also check `/proc/net/udp` and `/proc/net/udp6` as a fallback, which works without any additional tools installed.

## Testing

```
$ make interop-docker
...
Testing: moq-rs → moxygen (at draft-14)
✓ PASSED
...
Total:   2
Passed:  2
Failed:  0
```