### PR TITLE
Document connection ID naming conventions for TAP14 diagnostics

### DIFF
--- a/docs/tests/TEST-CASES.md
+++ b/docs/tests/TEST-CASES.md
@@ -14,6 +14,7 @@ Each test case follows this structure:
 - **Protocol References**: Relevant MoQT draft sections
 - **Procedure**: Step-by-step behavior
 - **Success Criteria**: What constitutes a pass
+- **Diagnostic Roles**: For multi-connection tests, the named roles for connection ID reporting (see [Connection ID Conventions](../TEST-CLIENT-INTERFACE.md#connection-id-conventions))
 - **mlog Events**: Suggested qlog/mlog events for validation (optional)
 
 ---
@@ -164,6 +165,8 @@ Each test case follows this structure:
 
 **Timeout**: 3 seconds total
 
+**Diagnostic Roles**: `publisher`, `subscriber` — report as `publisher_connection_id` and `subscriber_connection_id` in YAML diagnostics
+
 ---
 
 ### `subscribe-before-announce`
@@ -195,6 +198,8 @@ Each test case follows this structure:
 Both outcomes are valid relay behaviors. The test verifies the relay handles this scenario gracefully without crashing or hanging.
 
 **Timeout**: 3.5 seconds total
+
+**Diagnostic Roles**: `publisher`, `subscriber` — report as `publisher_connection_id` and `subscriber_connection_id` in YAML diagnostics (regardless of connection order)
 
 ---
 


### PR DESCRIPTION
## Summary

Standardizes how QUIC connection IDs are named in TAP14 YAML diagnostic blocks, addressing the fragility and ambiguity concerns raised in #6.

### Changes

- **TEST-CLIENT-INTERFACE.md**: Add "Connection ID Conventions" subsection documenting:
  - Single-connection tests use `connection_id`
  - Multi-connection tests use `<role>_connection_id` (named by logical role, not connection order)
  - Numbered suffix convention for future multi-subscriber tests
  - Best-effort reporting on partial failure (include whatever CIDs were captured)
  - Updated YAML diagnostics example to show a multi-connection test
- **TEST-CASES.md**: Add `Diagnostic Roles` to the test case format and to each multi-connection test case:
  - `announce-subscribe`: `publisher`, `subscriber`
  - `subscribe-before-announce`: `publisher`, `subscriber` (regardless of connection order)

### What this does NOT do (intentionally deferred)

- Does not add complex naming patterns (relay-to-relay, observer, etc.) — we'll address those when concrete test cases arise
- Does not make connection IDs mandatory — they remain OPTIONAL diagnostic metadata

Closes #6