### PR TITLE
fix(ci): don't skip publishing results when some tests fail

### DIFF
--- a/.github/workflows/interop-report.yml
+++ b/.github/workflows/interop-report.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Run interop tests
         working-directory: main
+        continue-on-error: true  # Some tests may fail — publish results regardless
         run: make interop-remote
 
       - name: Publish results


### PR DESCRIPTION
## Summary

- Add `continue-on-error: true` to the "Run interop tests" step so that the workflow continues to the publish step even when some interop tests fail

## Context

The first run of the interop report workflow (#11) failed because `run-interop-tests.sh` exits non-zero when any tests fail (9/11 passed, libquicr timed out). This caused the "Publish results" step to be skipped entirely, so no report was deployed.

For an interop test runner, partial failures are expected and the results are still valuable — that's the whole point of the report. This change lets the workflow publish results regardless of test outcomes.

Ref: https://github.com/englishm/moq-interop-runner/actions/runs/21800335143/job/62894695851