### PR TITLE
docs: clarify that adapters and builds work for both relays and clients

### DIFF
--- a/builds/README.md
+++ b/builds/README.md
@@ -9,7 +9,7 @@ Build Docker images from source code for MoQ implementations.
 - Ability to test unreleased code or specific branches
 - Local development workflows
 
-For most cases, **adapters** (wrapping existing Docker images) or **remote endpoints** (testing against public relays) are simpler. Use builds when you need source-level control.
+Builds can produce images for any role (relay, client, or both). For most cases, **adapters** (wrapping existing Docker images) or **remote endpoints** (testing against public relays) are simpler. Use builds when you need source-level control.
 
 Builds are opt-in and require explicit invocation - they don't run automatically during tests.
 


### PR DESCRIPTION
## Summary

- Update `adapters/README.md` to document client conventions alongside relay conventions, with an example client adapter
- Update `builds/README.md` to explicitly note that builds can produce images for any role

## Context

The adapter and build patterns both work for relays and clients, but the docs only described relay conventions. Since we're about to encourage WG members to add test clients (#13), the docs should make clear that adapters are an option for clients too — not just builds or pre-built registry images.