### PR TITLE
fix(ci): generate detail reports and include logs on gh-pages

### DIFF
--- a/.github/workflows/interop-report.yml
+++ b/.github/workflows/interop-report.yml
@@ -47,28 +47,34 @@ jobs:
 
           TIMESTAMP=$(basename "$NEW_RESULT")
           DEST="gh-pages-site/results/$TIMESTAMP"
-          
+
           mkdir -p "$DEST"
           cp -r "$NEW_RESULT/"* "$DEST/"
-          
-          # Generate index
+
+          # Copy mlogs into results if they exist (produced by Docker-based tests)
+          if [ -d main/mlog ] && [ "$(ls -A main/mlog/client 2>/dev/null)" ]; then
+            mkdir -p "$DEST/mlog"
+            cp -r main/mlog/* "$DEST/mlog/"
+          fi
+
+          # Generate index and detail reports for all runs
           cp main/generate-report.sh gh-pages-site/
           cp -r main/lib gh-pages-site/
-          
+
           cd gh-pages-site
-          ./generate-report.sh --index
-          
+          ./generate-report.sh
+
           mv results/index.html index.html
           # Safer replacement: only modify hrefs that look like dates (YYYY-)
           sed -i 's|href="\([0-9]\{4\}-\)|href="results/\1|g' index.html
-          
+
           rm generate-report.sh
           rm -rf lib
-          
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          
-          git add results/"$TIMESTAMP" index.html
+
+          git add .
           git commit -m "Add interop results for $TIMESTAMP"
           git push origin gh-pages
 


### PR DESCRIPTION
## Summary

- Generate per-run detail reports (`report.html`) in addition to the index page
- Include mlogs in published results when available (for future Docker-based tests)
- Use `git add .` to capture all generated files

## Problem

The interop report workflow was running `generate-report.sh --index`, which only generates the top-level index page. The `--index` flag causes the script to exit before calling `generate_detail()`, so no `report.html` files were created for individual test runs.

Result: clicking a test run on the [published site](https://englishm.github.io/moq-interop-runner/) returned a 404.

## Changes

1. **Drop `--index`** — Run `generate-report.sh` without flags so it generates both the index page and detail reports (`report.html`) for each run
2. **Copy mlogs** — If Docker-based tests produce mlog output (`mlog/client/`, `mlog/relay/`), copy them into the results directory. Remote-only tests don't produce mlogs, so this is a no-op today but ready for when Docker tests are added to CI.
3. **`git add .`** — Instead of explicitly listing files, add everything so generated `report.html` files and any other artifacts are captured