### PR TITLE
fix: only open browser on macOS, not Linux CI

### DIFF
--- a/generate-report.sh
+++ b/generate-report.sh
@@ -521,7 +521,9 @@ else
 fi
 
 # Open index in browser on macOS
-if command -v open &> /dev/null; then
+# Note: Linux has /usr/bin/open (openvt) which is not a browser launcher and
+# fails in headless CI environments, so restrict this to macOS only.
+if [[ "$(uname)" == "Darwin" ]] && command -v open &> /dev/null; then
     echo "Opening in browser..."
     open "$RESULTS_BASE/index.html"
 fi


### PR DESCRIPTION
## Summary

Restrict the auto-open-in-browser behavior in `generate-report.sh` to macOS only.

## Problem

The CI workflow failed at the publish step because `generate-report.sh` calls `open` to launch the report in a browser. On Ubuntu runners, `/usr/bin/open` exists (it's `openvt`/`xdg-open`) but fails with exit code 3 when no browser is available:

```
Opening in browser...
/usr/bin/open: 882: www-browser: not found
/usr/bin/open: 882: links2: not found
...
xdg-open: no method available for opening '...'
##[error]Process completed with exit code 3.
```

Since `set -euo pipefail` is active, this aborts the script before results are committed and pushed.

## Fix

Check for `uname == Darwin` before calling `open`. This is consistent with how the script already gates macOS-specific behavior (e.g., the `find`/`stat` commands at lines 30-36).

Ref: https://github.com/englishm/moq-interop-runner/actions/runs/21800978349