### PR TITLE
fix(ci): fix Docker test failures — jq syntax and cert permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@
 # For local Docker-based testing, you need to provide images.
 # See IMPLEMENTATIONS.md for how to register your implementation.
 
+SHELL := /bin/bash
+
 .PHONY: test test-verbose test-single test-external clean mlog-clean certs \
         interop-all interop-docker interop-remote interop-relay interop-list \
         relay-start relay-stop logs logs-relay logs-client \
@@ -153,14 +155,10 @@ interop-list:
 
 # Build all adapter images (reads build info from implementations.json)
 build-adapters:
-	@jq -r '.implementations | to_entries[] | .value.roles | to_entries[]? | \
-		select(.value.docker.build.dockerfile != null) | \
-		select(.value.docker.build.dockerfile | startswith("adapters/")) | \
-		"\(.value.docker.image)|\(.value.docker.build.dockerfile)|\(.value.docker.build.context)"' \
-		implementations.json | while IFS='|' read -r image dockerfile context; do \
-			echo "Building adapter: $$image"; \
-			docker build -t "$$image" -f "$$dockerfile" "$$context"; \
-		done
+	@set -o pipefail; jq -r '.implementations | to_entries[] | .value.roles | to_entries[]? | select(.value.docker.build.dockerfile != null) | select(.value.docker.build.dockerfile | startswith("adapters/")) | "\(.value.docker.image)|\(.value.docker.build.dockerfile)|\(.value.docker.build.context)"' implementations.json | while IFS='|' read -r image dockerfile context; do \
+		echo "Building adapter: $$image"; \
+		docker build -t "$$image" -f "$$dockerfile" "$$context"; \
+	done
 
 # Build individual adapter (kept for convenience / backward compatibility)
 build-moxygen-adapter:

--- a/generate-certs.sh
+++ b/generate-certs.sh
@@ -26,10 +26,11 @@ openssl req -x509 -newkey rsa:4096 \
     -subj "/CN=localhost" \
     -addext "subjectAltName=DNS:localhost,DNS:relay,DNS:moq-relay,IP:127.0.0.1"
 
-# Restrict private key permissions (owner read-only)
-chmod 600 "$CERTS_DIR/priv.key"
+# These are ephemeral self-signed test certs, not production secrets.
+# Use 644 so Docker containers running as a different UID can read them.
+chmod 644 "$CERTS_DIR/priv.key"
 chmod 644 "$CERTS_DIR/cert.pem"
 
 echo "Generated certificates in $CERTS_DIR:"
 echo "  - $CERTS_DIR/cert.pem (644)"
-echo "  - $CERTS_DIR/priv.key (600)"
+echo "  - $CERTS_DIR/priv.key (644)"


### PR DESCRIPTION
## Summary

All Docker-based interop tests were failing due to two independent issues:

- **`build-adapters` jq syntax error on Ubuntu**: The jq filter was split across multiple Make continuation lines, which broke on Ubuntu where `/bin/sh` is dash. The step silently succeeded (empty pipeline = `while` loop exits 0) without building any adapter images, causing `moxygen-interop:latest` to be missing at test time.

- **Relay can't read private key**: `generate-certs.sh` created `priv.key` with mode 600, but Docker containers run as UID 1000 while the GitHub Actions runner owns the file as UID 1001. Permission denied on mount.

## Fixes

1. Put the jq filter on a single line, add `SHELL := /bin/bash` to the Makefile, and use `set -o pipefail` so jq errors propagate properly.
2. Use mode 644 for the private key — these are ephemeral self-signed test certs, not production secrets.