### PR TITLE
fix(ci): continue on adapter build failure

### DIFF
--- a/.github/workflows/interop-report.yml
+++ b/.github/workflows/interop-report.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Build test clients and relays (with adapters)
         working-directory: main
+        continue-on-error: true  # Adapter builds may fail (e.g., disk space) — run what we can
         run: make build-adapters
 
       - name: Generate TLS certificates


### PR DESCRIPTION
## Summary

- The moxygen upstream image is 5.6GB and exhausts the GitHub Actions runner's disk after the moq-rs source build
- This caused the entire workflow to fail — no tests ran, no results published
- Add `continue-on-error: true` to the adapter build step so we still run remote tests + moq-rs Docker tests and publish results

The disk space issue for moxygen can be addressed separately (e.g., freeing runner disk space before builds, or caching layers).