### PR TITLE
Document --client filter flag

### DIFF
--- a/IMPLEMENTATIONS.md
+++ b/IMPLEMENTATIONS.md
@@ -172,6 +172,9 @@ Note: The moq-rs Dockerfiles and build configuration live in `builds/moq-rs/` in
 # Test specific relay
 ./run-interop-tests.sh --relay moxygen
 
+# Test specific client against all compatible relays
+./run-interop-tests.sh --client moq-rs
+
 # Filter by transport
 ./run-interop-tests.sh --quic-only
 ./run-interop-tests.sh --webtransport-only

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 SHELL := /bin/bash
 
 .PHONY: test test-verbose test-single test-external clean mlog-clean certs \
-        interop-all interop-docker interop-remote interop-relay interop-list \
+        interop-all interop-docker interop-remote interop-relay interop-client interop-list \
         relay-start relay-stop logs logs-relay logs-client \
         build-adapters build-moxygen-adapter build-impl build-moq-rs report help _ensure-certs
 
@@ -142,6 +142,10 @@ interop-remote:
 interop-relay:
 	@./run-interop-tests.sh --relay $(RELAY)
 
+# Run tests for specific client implementation
+interop-client:
+	@./run-interop-tests.sh --client $(CLIENT)
+
 # List available implementations
 interop-list:
 	@./run-interop-tests.sh --list
@@ -219,6 +223,7 @@ help:
 	@echo "  interop-docker        Run only Docker-based tests"
 	@echo "  interop-remote        Run only remote endpoint tests"
 	@echo "  interop-relay         Test specific relay: make interop-relay RELAY=moxygen"
+	@echo "  interop-client        Test specific client: make interop-client CLIENT=moq-rs"
 	@echo "  interop-list          List available implementations"
 	@echo ""
 	@echo "Single Tests (requires Docker images):"
@@ -251,6 +256,7 @@ help:
 	@echo "Examples:"
 	@echo "  make interop-remote                              # Test all public relays"
 	@echo "  make interop-relay RELAY=moxygen                 # Test moxygen only"
+	@echo "  make interop-client CLIENT=moq-rs               # Test moq-rs client only"
 	@echo "  make test RELAY_IMAGE=moxygen-interop:latest     # Test with moxygen Docker"
 	@echo "  make test-external RELAY_URL=https://example.com # Test specific URL"
 	@echo "  make build-moq-rs BUILD_ARGS=\"--local ~/git/moq-rs\"  # Build from local"

--- a/docs/VERSION-MATCHING.md
+++ b/docs/VERSION-MATCHING.md
@@ -63,13 +63,14 @@ Filters narrow the plan without changing version computation:
 | `--only-ahead-of-target` | Keep only pairs classified `ahead` | Pair-level |
 | `--only-behind-target` | Keep only pairs classified `behind` | Pair-level |
 | `--relay NAME` | Restrict to one relay | Pair-level |
+| `--client NAME` | Restrict to one client | Pair-level |
 | `--docker-only` | Drop remote endpoints | Endpoint-level |
 | `--remote-only` | Drop Docker endpoints | Endpoint-level |
 | `--transport TYPE` | Keep only remote endpoints matching TYPE | Endpoint-level |
 | `--quic-only` | Shorthand for `--transport quic` | Endpoint-level |
 | `--webtransport-only` | Shorthand for `--transport webtransport` | Endpoint-level |
 
-Classification filters and `--relay` apply before endpoint expansion. Transport filters apply during expansion. Only one `--only-*` flag is allowed. `--docker-only` and `--remote-only` are mutually exclusive.
+Classification filters, `--relay`, and `--client` apply before endpoint expansion. Transport filters apply during expansion. Only one `--only-*` flag is allowed. `--docker-only` and `--remote-only` are mutually exclusive.
 
 Note: transport filters (`--transport`, `--quic-only`, `--webtransport-only`) only affect remote endpoints. Docker tests still run unless `--remote-only` is also set.
 


### PR DESCRIPTION
## Summary

Follow-up to #20. Documents the new `--client` filter flag across the repo:

- **Makefile**: Adds `interop-client` target (mirrors `interop-relay`) and corresponding help text / examples
- **docs/VERSION-MATCHING.md**: Adds `--client NAME` to the filter table and mentions it in the prose alongside `--relay`
- **IMPLEMENTATIONS.md**: Adds a usage example showing `./run-interop-tests.sh --client moq-rs`

This is useful for quickly testing a new test-client implementation against all compatible relays.