### PR TITLE
Fix broken 'All Runs' back-link in detail report pages

### DIFF
--- a/.github/workflows/interop-report.yml
+++ b/.github/workflows/interop-report.yml
@@ -76,6 +76,8 @@ jobs:
           mv results/index.html index.html
           # Safer replacement: only modify hrefs that look like dates (YYYY-)
           sed -i 's|href="\([0-9]\{4\}-\)|href="results/\1|g' index.html
+          # Fix back-links in detail reports: index.html moved from results/ to site root
+          sed -i 's|href="../index.html"|href="../../index.html"|g' results/*/report.html
 
           rm generate-report.sh
           rm -rf lib


### PR DESCRIPTION
## Summary

- Fixes the broken "All Runs" (`← All Runs`) navigation link on detail report pages deployed to GitHub Pages
- The CI workflow moves `index.html` from `results/` to the site root but only rewrites forward links (index → detail), leaving backward links (detail → index) pointing to the now-nonexistent `results/index.html`
- Adds a `sed` command to rewrite back-links from `../index.html` to `../../index.html` so they resolve to the site root

## Root Cause

`generate-report.sh` generates detail reports at `results/<timestamp>/report.html` with `<a href="../index.html">` back-links. The CI workflow (`interop-report.yml`) moves `index.html` to the site root and fixes forward links with `sed`, but never adjusts the backward links. On the deployed site, `results/index.html` is a 404.

**Example:** https://englishm.github.io/moq-interop-runner/results/2026-02-10_003832/report.html → links to https://englishm.github.io/moq-interop-runner/results/index.html (404)

## Validation

Simulated the CI workflow locally:
- Before fix: `href="../index.html"` → resolves to `results/index.html` (404)
- After fix: `href="../../index.html"` → resolves to root `index.html` (correct)

Fixes #25