### PR TITLE
[DRAFT] Add moq-rs-draft-16 implementation entry

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -40,6 +40,28 @@
       }
     },
 
+    "moq-rs-draft-16": {
+      "name": "moq-rs (draft-16)",
+      "organization": "Cloudflare",
+      "repository": "https://github.com/cloudflare/moq-rs",
+      "draft_versions": ["draft-16"],
+      "notes": "Rust implementation. Draft-16 branch from https://github.com/cloudflare/moq-rs/pull/131",
+      "roles": {
+        "relay": {
+          "docker": {
+            "image": "moq-relay-ietf-draft-16:latest",
+            "notes": "Build: ./builds/moq-rs/build.sh --local /path/to/moq-rs-draft-16 --target relay && docker tag moq-relay-ietf:latest moq-relay-ietf-draft-16:latest"
+          }
+        },
+        "client": {
+          "docker": {
+            "image": "moq-test-client-draft-16:latest",
+            "notes": "Build: ./builds/moq-rs/build.sh --local /path/to/moq-rs-draft-16 --target client && docker tag moq-test-client:latest moq-test-client-draft-16:latest"
+          }
+        }
+      }
+    },
+
     "moxygen": {
       "name": "moxygen",
       "organization": "Meta",


### PR DESCRIPTION
## Summary

Adds a `moq-rs-draft-16` entry to `implementations.json` for interop testing of MoQT draft-16 support in moq-rs.

This tracks the draft-16 branch from [cloudflare/moq-rs#131](https://github.com/cloudflare/moq-rs/pull/131) (by @itzmanish).

### What's included

- New `moq-rs-draft-16` implementation entry with Docker build instructions for both relay and client roles
- Separate from the existing `moq-rs` entry (which remains on draft-14) to allow parallel testing

### Status

WIP — iterating on draft-16 interop testing with other implementations. Known issues:
- WebTransport connection to `quichemoq.dev` fails (server doesn't send `ENABLE_DATAGRAM`/`WEBTRANSPORT_MAX_SESSIONS` settings)
- moq-rs uses outdated `web-transport` crates (v0.3 vs latest v0.10+), upgrade in progress

### Related

- #31 (merged) — Updated `current_target` to `draft-16`
- #29 (merged) — quiche-moq draft-16 update by @martinduke