### PR TITLE
Update interop target to draft-16

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -3,7 +3,7 @@
   "version": "1.1",
   "description": "MoQT implementation registry for interop testing",
 
-  "current_target": "draft-14",
+  "current_target": "draft-16",
 
   "implementations": {
     "moq-rs": {

--- a/run-interop-tests.sh
+++ b/run-interop-tests.sh
@@ -130,7 +130,7 @@ fi
 
 # Read target version from config if not specified via CLI
 if [ -z "$TARGET_VERSION" ]; then
-    TARGET_VERSION=$(jq -r '.current_target // "draft-14"' "$CONFIG_FILE")
+    TARGET_VERSION=$(jq -r '.current_target // "draft-16"' "$CONFIG_FILE")
 fi
 
 # Validate target version format


### PR DESCRIPTION
## Summary

- Sets `current_target` to `draft-16` in `implementations.json`, making it the official interop target
- Updates the fallback default in `run-interop-tests.sh` to match