### PR TITLE
Update imquic to draft-17, drop versions below draft-16

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -219,8 +219,8 @@
       "name": "imquic",
       "organization": "Meetecho",
       "repository": "https://github.com/meetecho/imquic",
-      "draft_versions": ["draft-16", "draft-15", "draft-14", "draft-13", "draft-12", "draft-11"],
-      "notes": "C implementation. Supports multiple draft versions via negotiation.",
+      "draft_versions": ["draft-17", "draft-16"],
+      "notes": "C implementation. Supports draft-17 and draft-16 via negotiation. Versions below draft-16 were dropped when draft-17 support was added (March 2026).",
       "roles": {
         "relay": {
           "remote": [


### PR DESCRIPTION
## Summary
- Updates the imquic (Meetecho) entry to reflect that Lorenzo's relay now supports **draft-17 and draft-16 only**
- Versions below draft-16 (draft-15, draft-14, draft-13, draft-12, draft-11) were dropped when draft-17 support was added

## Context
@lminiero updated his online relay (`lminiero.it:9000`) to draft-17 in early March 2026. The significant protocol changes in draft-17 (new MoQ-specific varint encoding, streams model, parameters no longer TLV, GREASE, etc.) made it impractical to maintain backward compatibility below draft-16.

The interop target remains draft-16 — this just ensures the version matcher won't try to test old draft versions against imquic's relay when they're no longer supported.