### PR TITLE
Add moqx (OpenMOQ) relay

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -114,6 +114,30 @@
       }
     },
 
+    "moqx": {
+      "name": "moqx",
+      "organization": "OpenMOQ",
+      "repository": "https://github.com/openmoq/moqx",
+      "draft_versions": ["draft-14", "draft-15", "draft-16"],
+      "notes": "C++ relay built on moxygen. Supports multiple draft versions via version negotiation.",
+      "roles": {
+        "relay": {
+          "remote": [
+            {
+              "url": "https://moqx-000.ci.openmoq.org:4433/moq-relay",
+              "transport": "webtransport",
+              "notes": "CI-deployed relay"
+            },
+            {
+              "url": "moqt://moqx-000.ci.openmoq.org:4433",
+              "transport": "quic",
+              "notes": "CI-deployed relay"
+            }
+          ]
+        }
+      }
+    },
+
     "moq-dev-rs": {
       "name": "moq (moq-dev)",
       "organization": "Luke Curley",


### PR DESCRIPTION
Adds moqx as a remote-only relay implementation.

- **Endpoint:** `moqx-000.ci.openmoq.org:4433`
- **Transports:** WebTransport + raw QUIC
- **Draft versions:** 14, 15, 16 (version negotiation)
- **Built on:** [moxygen](https://github.com/facebookexperimental/moxygen) (C++)
- **Repo:** [openmoq/moqx](https://github.com/openmoq/moqx)

The relay is CI-deployed and continuously updated on every push to main.