### PR TITLE
Fix xquic build: pin Tongsuo to 8.4.0

### DIFF
--- a/builds/xquic/Dockerfile.client
+++ b/builds/xquic/Dockerfile.client
@@ -19,7 +19,7 @@ WORKDIR /build
 
 COPY . /build/xquic
 
-RUN git clone --depth 1 https://github.com/Tongsuo-Project/Tongsuo.git /build/babassl && \
+RUN git clone --depth 1 --branch 8.4.0 https://github.com/Tongsuo-Project/Tongsuo.git /build/babassl && \
     cd /build/babassl && \
     ./Configure --api=1.1.1 no-deprecated && \
     make -j$(nproc)

--- a/builds/xquic/Dockerfile.relay
+++ b/builds/xquic/Dockerfile.relay
@@ -19,7 +19,7 @@ WORKDIR /build
 
 COPY . /build/xquic
 
-RUN git clone --depth 1 https://github.com/Tongsuo-Project/Tongsuo.git /build/babassl && \
+RUN git clone --depth 1 --branch 8.4.0 https://github.com/Tongsuo-Project/Tongsuo.git /build/babassl && \
     cd /build/babassl && \
     ./Configure --api=1.1.1 no-deprecated && \
     make -j$(nproc)

--- a/implementations.json
+++ b/implementations.json
@@ -114,6 +114,30 @@
       }
     },
 
+    "moqx": {
+      "name": "moqx",
+      "organization": "OpenMOQ",
+      "repository": "https://github.com/openmoq/moqx",
+      "draft_versions": ["draft-14", "draft-15", "draft-16"],
+      "notes": "C++ relay built on moxygen. Supports multiple draft versions via version negotiation.",
+      "roles": {
+        "relay": {
+          "remote": [
+            {
+              "url": "https://moqx-000.ci.openmoq.org:4433/moq-relay",
+              "transport": "webtransport",
+              "notes": "CI-deployed relay"
+            },
+            {
+              "url": "moqt://moqx-000.ci.openmoq.org:4433",
+              "transport": "quic",
+              "notes": "CI-deployed relay"
+            }
+          ]
+        }
+      }
+    },
+
     "moq-dev-rs": {
       "name": "moq (moq-dev)",
       "organization": "Luke Curley",


### PR DESCRIPTION
## Summary

xquic Docker builds fail because Tongsuo `main` renamed the QUIC SSL APIs
(e.g. `SSL_set_quic_method` → `SSL_set_quic_tls_method`,
`SSL_QUIC_METHOD` removed). Pin to Tongsuo 8.4.0 which has the
compatible API.

Verified: `xquic-moq-client:latest` builds clean with this fix.

## Changes

- `builds/xquic/Dockerfile.client`: pin `--branch 8.4.0`
- `builds/xquic/Dockerfile.relay`: pin `--branch 8.4.0`