### PR TITLE
Add moqlivemock (Eyevinn) as interop test client

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -287,6 +287,22 @@
       }
     },
 
+    "moqlivemock": {
+      "name": "moqlivemock",
+      "organization": "Eyevinn",
+      "repository": "https://github.com/Eyevinn/moqlivemock",
+      "draft_versions": ["draft-14", "draft-16"],
+      "notes": "Go implementation. Test client for MoQ interop testing.",
+      "roles": {
+        "client": {
+          "docker": {
+            "image": "ghcr.io/eyevinn/mlmtest:latest",
+            "notes": "Published from Eyevinn/moqlivemock CI. Supports RELAY_URL, TESTCASE, TLS_DISABLE_VERIFY, DRAFT env vars."
+          }
+        }
+      }
+    },
+
     "xquic": {
       "name": "xquic",
       "organization": "Alibaba",

--- a/implementations.json
+++ b/implementations.json
@@ -292,13 +292,27 @@
       "organization": "Eyevinn",
       "repository": "https://github.com/Eyevinn/moqlivemock",
       "draft_versions": ["draft-14", "draft-16"],
-      "notes": "Go implementation. Test client for MoQ interop testing.",
+      "notes": "Go implementation. Test client and live CMAF publisher. Publisher announces the moq-test/interop namespace for interop testing.",
       "roles": {
         "client": {
           "docker": {
             "image": "ghcr.io/eyevinn/mlmtest:latest",
             "notes": "Published from Eyevinn/moqlivemock CI. Supports RELAY_URL, TESTCASE, TLS_DISABLE_VERIFY, DRAFT env vars."
           }
+        },
+        "publisher": {
+          "remote": [
+            {
+              "url": "https://moqlivemock.demo.osaas.io:443/moq",
+              "transport": "webtransport",
+              "notes": "Live CMAF publisher (video + audio + subtitles)"
+            },
+            {
+              "url": "moqt://moqlivemock.demo.osaas.io:443",
+              "transport": "quic",
+              "notes": "Live CMAF publisher (video + audio + subtitles)"
+            }
+          ]
         }
       }
     },


### PR DESCRIPTION
## Summary

- Adds [moqlivemock](https://github.com/Eyevinn/moqlivemock) as a **client** implementation supporting draft-14 and draft-16
- Docker image: `ghcr.io/eyevinn/mlmtest:latest` (built by GitHub Actions CI)
- Implements all 6 test cases, outputs TAP v14, supports RELAY_URL/TESTCASE/TLS_DISABLE_VERIFY env vars

### DRAFT environment variable

mlmtest also accepts a `DRAFT` environment variable (values: `14` or `16`, default: `16`) to select the MoQ Transport draft version and ALPN (`moq-00` for draft-14, `moqt-16` for draft-16).

Since the runner computes the negotiated version per pair but doesn't currently pass it to the client, this means:
- Pairing with a **draft-16** relay works out of the box (our default)
- Pairing with a **draft-14-only** relay would fail at ALPN unless `DRAFT=14` is passed

If the runner doesn't plan to pass a draft env var, we can also just register as draft-16 only for now.

## Verified against

All 6 tests pass against these relays (tested 2026-04-12):

| Relay | Draft | Result |
|-------|-------|--------|
| moq-rs (Cloudflare) | 16 | 6/6 pass |
| moxygen (Meta) | 16 | 6/6 pass |
| moqx (OpenMOQ) | 16 | 6/6 pass |
| imquic (Meetecho) | 16 | 6/6 pass |
| moq-rs (Cloudflare) | 14 | 6/6 pass |

## Quick test

```bash
docker run --rm \
  -e RELAY_URL=moqt://draft-16-manish.cloudflare.mediaoverquic.com:443 \
  -e TLS_DISABLE_VERIFY=1 \
  ghcr.io/eyevinn/mlmtest:latest
```