### PR TITLE
Add moqx client role

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -134,6 +134,11 @@
               "notes": "CI-deployed relay"
             }
           ]
+        },
+        "client": {
+          "docker": {
+            "image": "ghcr.io/openmoq/moqx-interop-client:latest"
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary
Adds a \`client\` role block to moqx's existing entry in \`implementations.json\`. Mirrors the pattern moxygen already uses.

moqx is currently registered relay-only, so it only appears in the relay column of the interop matrix. The moqx project already publishes an interop-client image (built alongside the relay image from the same tarball via multi-stage \`FROM debian:bookworm AS builder\`), so wiring it in here closes the loop.

## Diff
\`\`\`json
"moqx": {
  ...
  "roles": {
    "relay": { ... },
    "client": {
      "docker": {
        "image": "ghcr.io/openmoq/moqx-interop-client:latest"
      }
    }
  }
}
\`\`\`

## Image details
- **Image**: \`ghcr.io/openmoq/moqx-interop-client:latest\` (multi-arch: amd64 + arm64 manifest list)
- **Also tagged**: \`:<short-sha>\` per-build; \`:main-latest\` rolling; \`:latest\` back-compat alias on main pushes
- **Base**: \`debian:bookworm-slim\`
- **Source**: [openmoq/moqx docker/Dockerfile.interop-client](https://github.com/openmoq/moqx/blob/main/docker/Dockerfile.interop-client)
- **CI**: auto-built + pushed on every push to \`main\` / \`release/**\` by [ci-main.yml publish job](https://github.com/openmoq/moqx/blob/main/.github/workflows/ci-main.yml)

## Runner conventions
The binary honors the runner's env-var conventions natively:
- \`RELAY_URL\` — target URL
- \`TESTCASE\` — per-test dispatch
- \`TLS_DISABLE_VERIFY\` — insecure mode for dev certs
- \`VERBOSE\` — GLOG verbosity

Output is TAP v14 to stdout. Same interface as moxygen's moq-interop-client since both link the same moxygen client library.

## Test plan
- [ ] \`generate-report.sh\` renders moqx in both relay and client columns
- [ ] moqx-as-client × moxygen-as-relay passes setup + announce suites
- [ ] moqx-as-client × moq-dev-js-as-relay passes setup suite