### PR TITLE
Add aiomoqt (Python asyncio MoQT client) to implementation registry

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -307,6 +307,22 @@
           }
         }
       }
+    },
+
+    "aiomoqt": {
+      "name": "aiomoqt",
+      "organization": "MarzResearch",
+      "repository": "https://github.com/gmarzot/aiomoqt",
+      "draft_versions": ["draft-14", "draft-16"],
+      "notes": "Python asyncio implementation of MoQT. Supports draft-14 and draft-16 via version negotiation.",
+      "roles": {
+        "client": {
+          "docker": {
+            "image": "ghcr.io/gmarzot/aiomoqt:latest",
+            "notes": "Pre-built on GHCR from the upstream repo (see Dockerfile at the repo root). Available in :latest and :<version> tags."
+          }
+        }
+      }
     }
   },
 


### PR DESCRIPTION
## Summary

Adds [aiomoqt](https://github.com/gmarzot/aiomoqt) — a Python asyncio MoQT implementation — to the client implementation registry.

**Pre-built public image**: \`ghcr.io/gmarzot/aiomoqt:latest\` (also tagged \`:0.8.1\` for the initial release).

## Implementation details

- Python >=3.12, built on qh3 for QUIC/H3/WebTransport.
- Supports **draft-14** and **draft-16** via SETUP version negotiation.
- Client role only (no relay ships yet).

## Test client contract (per \`TEST-CLIENT-INTERFACE.md\`)

- **Env vars**: \`RELAY_URL\`, \`TESTCASE\`, \`TLS_DISABLE_VERIFY\`, \`VERBOSE\`
- **CLI flags**: \`-r / --relay\`, \`-t / --test\`, \`-l / --list\`, \`-v / --verbose\`, \`--tls-disable-verify\`
- **Output**: TAP v14 on stdout (with YAML diagnostic blocks)
- **Exit codes**: \`0\` (all passed) / \`1\` (any failed) / \`127\` (unknown test case)

## Test cases registered

Standard six from the interop runner spec:
- \`setup-only\`
- \`announce-only\`
- \`publish-namespace-done\`
- \`subscribe-error\` (validates against \`TRACK_DOES_NOT_EXIST\`: d14 0x04 / d16 0x10)
- \`announce-subscribe\`
- \`subscribe-before-announce\`

Plus two probes (beyond the standard six):
- \`fetch\` — standalone FETCH against a non-existent track; accepts FETCH_OK or a benign structured FETCH_ERROR
- \`join\` — SUBSCRIBE + JOINING_FETCH probe

## Verification

\`\`\`
docker pull ghcr.io/gmarzot/aiomoqt:0.8.1
docker run --rm ghcr.io/gmarzot/aiomoqt:0.8.1 -l
docker run --rm -e RELAY_URL=moqt://moqx-main.ci.openmoq.org:4433 \
  ghcr.io/gmarzot/aiomoqt:0.8.1 --draft 14
# -> ok 1..6, TAP v14 output
\`\`\`

## Test plan

- [ ] Runner can pull \`ghcr.io/gmarzot/aiomoqt:latest\` without auth
- [ ] \`TESTCASE\` / \`RELAY_URL\` env vars propagate into the entrypoint
- [ ] TAP output parses cleanly in the runner's reporter
- [ ] Draft pairing works (\`--draft 14\` / \`--draft 16\`)

---

Happy to adjust the entry or ship additional roles/test cases if useful for the runner. Thanks for maintaining this!