### PR TITLE
Add per-test timeout to prevent hanging tests from blocking CI

### DIFF
--- a/.github/workflows/interop-report.yml
+++ b/.github/workflows/interop-report.yml
@@ -22,6 +22,7 @@ jobs:
   test-and-publish:
     if: github.repository == 'englishm/moq-interop-runner'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout main
         uses: actions/checkout@v4

--- a/run-interop-tests.sh
+++ b/run-interop-tests.sh
@@ -368,6 +368,10 @@ run_test() {
     local status="unknown"
     local exit_code=0
 
+    # Per-test timeout in seconds (default: 120s).
+    # A hanging client (e.g. blocked on handshake) will be killed after this.
+    local test_timeout="${TEST_TIMEOUT:-120}"
+
     # Resolve client Docker image from implementations.json
     local client_image
     client_image=$(jq -r --arg c "$client" '.implementations[$c].roles.client.docker.image // empty' "$CONFIG_FILE")
@@ -378,30 +382,42 @@ run_test() {
     fi
 
     if [[ "$mode" == "docker" ]]; then
-        if make test RELAY_IMAGE="$target" CLIENT_IMAGE="$client_image" > "$result_file" 2>&1; then
+        if timeout "$test_timeout" make test RELAY_IMAGE="$target" CLIENT_IMAGE="$client_image" > "$result_file" 2>&1; then
             status="pass"
             PASSED=$((PASSED + 1))
             echo -e "${GREEN}✓ PASSED${NC}"
         else
             exit_code=$?
-            status="fail"
-            FAILED=$((FAILED + 1))
-            echo -e "${RED}✗ FAILED (exit code: $exit_code)${NC}"
+            if [ "$exit_code" -eq 124 ]; then
+                status="timeout"
+                FAILED=$((FAILED + 1))
+                echo -e "${RED}⧖ TIMEOUT (killed after ${test_timeout}s)${NC}"
+            else
+                status="fail"
+                FAILED=$((FAILED + 1))
+                echo -e "${RED}✗ FAILED (exit code: $exit_code)${NC}"
+            fi
         fi
     else
         # Build make arguments as array to avoid word splitting issues
         local -a make_args=("test-external" "RELAY_URL=$target" "CLIENT_IMAGE=$client_image")
         [ "$tls_disable" = "true" ] && make_args+=("TLS_DISABLE_VERIFY=1")
 
-        if make "${make_args[@]}" > "$result_file" 2>&1; then
+        if timeout "$test_timeout" make "${make_args[@]}" > "$result_file" 2>&1; then
             status="pass"
             PASSED=$((PASSED + 1))
             echo -e "${GREEN}✓ PASSED${NC}"
         else
             exit_code=$?
-            status="fail"
-            FAILED=$((FAILED + 1))
-            echo -e "${RED}✗ FAILED (exit code: $exit_code)${NC}"
+            if [ "$exit_code" -eq 124 ]; then
+                status="timeout"
+                FAILED=$((FAILED + 1))
+                echo -e "${RED}⧖ TIMEOUT (killed after ${test_timeout}s)${NC}"
+            else
+                status="fail"
+                FAILED=$((FAILED + 1))
+                echo -e "${RED}✗ FAILED (exit code: $exit_code)${NC}"
+            fi
         fi
     fi
 


### PR DESCRIPTION
## Problem

Every daily CI run since May 14 has been cancelled at the 6-hour GitHub Actions default timeout. The `Run interop tests` step never completes.

**Timeline:**
- **May 13 00:40 UTC** — last successful run (test step took ~14 minutes)
- **May 13 ~17:25 EDT** — PRs #63 (moqlivemock), #65, #66, #67 merged
- **May 14 00:40 UTC → present** — every daily run hangs and gets cancelled at 6h

**Root cause:** The moqlivemock client (`ghcr.io/eyevinn/mlmtest:latest`) hangs indefinitely when tested against moq-rs-draft-16 in docker mode. It connects, prints its TAP header and a quic-go UDP buffer warning, then blocks forever — likely stuck during version negotiation or session setup. Since `run-interop-tests.sh` had no per-test timeout, this single hanging pair blocked the entire sequential test run.

Reproduced locally — the test hangs until killed.

## Fix

**Per-test timeout** (`run-interop-tests.sh`):
- Wrap every `make test` and `make test-external` invocation in `timeout` (default: 120s)
- Configurable via `TEST_TIMEOUT` env var for debugging
- Timed-out tests report `⧖ TIMEOUT` in console output and `"status": "timeout"` with `"exit_code": 124` in summary JSON, distinct from normal failures

**Job-level safety net** (`interop-report.yml`):
- Added `timeout-minutes: 60` to the workflow job
- The full matrix completes in ~15 min normally; 60 min gives plenty of headroom while preventing another 6-hour wait if something else hangs

## Not in scope

The underlying moqlivemock hang is likely a version negotiation or session setup bug in that client — to be filed/investigated separately. This PR just makes the runner resilient so we can see where the full matrix stands.