### PR TITLE
moqx: add relay docker adapter, update remote URLs, register publisher

### DIFF
--- a/adapters/moqx/Dockerfile.relay
+++ b/adapters/moqx/Dockerfile.relay
@@ -1,0 +1,27 @@
+# moqx adapter for MoQT interop testing
+#
+# Wraps the published moqx relay image with standard interop conventions:
+# - Reads certs from /certs/cert.pem and /certs/priv.key
+# - Listens on UDP 4443 (runner convention) with endpoint path "/"
+# - moqx-specific env vars (MOQX_*) are documented in moqx/docker/entrypoint.sh
+#
+# Build:
+#   docker build -t moqx-interop:latest -f adapters/moqx/Dockerfile.relay adapters/moqx/
+#
+# Usage:
+#   docker run -v ./certs:/certs -p 4443:4443/udp moqx-interop:latest
+
+FROM ghcr.io/openmoq/moqx:latest
+
+ENV MOQX_PORT=4443
+ENV MOQX_BIND_ADDR=0.0.0.0
+ENV MOQX_CERT=/certs/cert.pem
+ENV MOQX_KEY=/certs/priv.key
+ENV MOQX_ENDPOINT=/
+
+EXPOSE 4443/udp
+
+# Custom healthcheck — the slim runtime image doesn't ship ss/netstat.
+# Probe /proc/net/udp{,6} for hex port 0x115B (= 4443).
+HEALTHCHECK --interval=2s --timeout=5s --start-period=5s --retries=10 \
+    CMD grep -qi ":115B" /proc/net/udp6 || grep -qi ":115B" /proc/net/udp || exit 1

--- a/implementations.json
+++ b/implementations.json
@@ -122,14 +122,23 @@
       "notes": "C++ relay built on moxygen. Supports multiple draft versions via version negotiation.",
       "roles": {
         "relay": {
+          "docker": {
+            "image": "moqx-interop:latest",
+            "build": {
+              "dockerfile": "adapters/moqx/Dockerfile.relay",
+              "context": "adapters/moqx"
+            },
+            "upstream_image": "ghcr.io/openmoq/moqx:latest",
+            "notes": "Adapter wraps upstream image with /certs convention"
+          },
           "remote": [
             {
-              "url": "https://moqx-000.ci.openmoq.org:4433/moq-relay",
+              "url": "https://moqx-main.ci.openmoq.org:4433/moq-relay",
               "transport": "webtransport",
               "notes": "CI-deployed relay"
             },
             {
-              "url": "moqt://moqx-000.ci.openmoq.org:4433",
+              "url": "moqt://moqx-main.ci.openmoq.org:4433",
               "transport": "quic",
               "notes": "CI-deployed relay"
             }
@@ -139,6 +148,20 @@
           "docker": {
             "image": "ghcr.io/openmoq/moqx-interop-client:latest"
           }
+        },
+        "publisher": {
+          "remote": [
+            {
+              "url": "https://moqx-main.ci.openmoq.org:4433/moq-relay",
+              "transport": "webtransport",
+              "notes": "CI-deployed relay; subscribe target for moq-test/interop namespace"
+            },
+            {
+              "url": "moqt://moqx-main.ci.openmoq.org:4433",
+              "transport": "quic",
+              "notes": "CI-deployed relay; subscribe target for moq-test/interop namespace"
+            }
+          ]
         }
       }
     },


### PR DESCRIPTION
## Summary

Three updates to the `moqx` entry in `implementations.json`, plus a new adapter Dockerfile:

1. **Register moqx as a docker-buildable relay.** New `adapters/moqx/Dockerfile.relay` wraps `ghcr.io/openmoq/moqx:latest` with the runner's `/certs` convention and UDP port 4443. Adds `roles.relay.docker` to the implementation entry. Mirrors the moxygen adapter pattern.

2. **Update relay remote URLs** from `moqx-000.ci.openmoq.org` → `moqx-main.ci.openmoq.org`. moqx-main is the stable CI-deployed hostname; moqx-000 was an interim alias kept for backward compatibility while we transitioned.

3. **Register publisher role** under `roles.publisher.remote` pointing at moqx-main. Metadata-only today (the runner doesn't dispatch publisher tests yet), but registered for when it does.

## Why

[openmoq/moqx#316](https://github.com/openmoq/moqx/issues/316) asked why moqx only runs 12/12 tests vs moq-rs's 18/18 in the matrix. Answer: moqx was registered with only `remote` endpoints (WT + raw QUIC = 2 transport modes × 6 tests = 12), missing the docker mode that moxygen and moq-rs provide. This PR adds the third mode.

Required prereq landed upstream first: [openmoq/moqx#319](https://github.com/openmoq/moqx/pull/319) added a `MOQX_ENDPOINT` env var to the moqx docker entrypoint so the adapter can override the endpoint path to `/` (default is `/moq-relay`). The republished `ghcr.io/openmoq/moqx:latest` digest is `sha256:2b1f29b1...`.

## Test plan

All validated locally against the freshly-published `ghcr.io/openmoq/moqx:latest`:

| Client → moqx relay (docker) | Result |
|---|---|
| moqx → moqx | 6/6 ✓ |
| moxygen → moqx | 6/6 ✓ |
| moq-rs → moqx (draft-14) | 6/6 ✓ |
| moq-rs-draft-16 → moqx | 6/6 ✓ |
| aiomoqt → moqx | 6/6 ✓ |
| moqlivemock → moqx | 6/6 ✓ |

Remote URLs (moqx-main) re-verified for moqx-as-client and moqx-as-relay:

| Pairing | WT | QUIC |
|---|---|---|
| moqx → moqx (remote) | 6/6 ✓ | 6/6 ✓ |

JSON validates against `implementations.schema.json`. Adapter builds clean via `make build-adapters`.

Expected impact on next matrix: moqx-as-relay column moves from 13/18 (no docker) to ~75+/162 with full docker bringup for well-behaved clients (moqx, moxygen, moq-rs-*, aiomoqt, moqlivemock all reaching 18/18 against moqx).