### PR TITLE
Reorder existing ones in the implementation registry

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -2,15 +2,142 @@
   "$schema": "./implementations.schema.json",
   "version": "1.1",
   "description": "MoQT implementation registry for interop testing",
-
   "current_target": "draft-18",
-
   "implementations": {
+    "aiomoqt": {
+      "name": "aiomoqt",
+      "organization": "MarzResearch",
+      "repository": "https://github.com/gmarzot/aiomoqt",
+      "draft_versions": [
+        "draft-14",
+        "draft-16"
+      ],
+      "notes": "Python asyncio implementation of MoQT. Supports draft-14 and draft-16 via version negotiation.",
+      "roles": {
+        "client": {
+          "docker": {
+            "image": "ghcr.io/gmarzot/aiomoqt:latest",
+            "notes": "Pre-built on GHCR from the upstream repo (see Dockerfile at the repo root). Available in :latest and :<version> tags."
+          }
+        }
+      }
+    },
+    "imquic": {
+      "name": "imquic",
+      "organization": "Meetecho",
+      "repository": "https://github.com/meetecho/imquic",
+      "draft_versions": [
+        "draft-17",
+        "draft-16"
+      ],
+      "notes": "C implementation. Supports draft-17 and draft-16 via negotiation. Versions below draft-16 were dropped when draft-17 support was added (March 2026).",
+      "roles": {
+        "relay": {
+          "remote": [
+            {
+              "url": "https://lminiero.it:9000",
+              "transport": "webtransport"
+            },
+            {
+              "url": "moqt://lminiero.it:9000",
+              "transport": "quic"
+            }
+          ]
+        }
+      }
+    },
+    "libquicr": {
+      "name": "libquicr",
+      "organization": "Cisco",
+      "repository": "https://github.com/Quicr/libquicr",
+      "draft_versions": [
+        "draft-14"
+      ],
+      "notes": "C++ implementation",
+      "roles": {
+        "relay": {
+          "remote": [
+            {
+              "url": "https://us-west-2.relay.quicr.org:33437/relay",
+              "transport": "webtransport",
+              "tls_disable_verify": true,
+              "notes": "WebTransport endpoint"
+            },
+            {
+              "url": "moqt://us-west-2.relay.quicr.org:33437",
+              "transport": "quic",
+              "tls_disable_verify": true,
+              "notes": "Raw QUIC endpoint"
+            }
+          ]
+        }
+      }
+    },
+    "moq-dev-js": {
+      "name": "moq (moq-dev, JS)",
+      "organization": "Luke Curley",
+      "repository": "https://github.com/moq-dev/moq",
+      "draft_versions": [
+        "draft-14",
+        "draft-15",
+        "draft-16",
+        "draft-17"
+      ],
+      "notes": "Bun/TypeScript test client using @moq/lite npm package with @moq/web-transport polyfill. Supports multiple draft versions via version negotiation.",
+      "roles": {
+        "client": {
+          "docker": {
+            "image": "ghcr.io/englishm/moq-interop-runner-moq-dev-js-client:latest",
+            "notes": "Pre-built on GHCR. To build from source: ./builds/moq-dev-js/build.sh && docker tag moq-dev-js-client:latest ghcr.io/englishm/moq-interop-runner-moq-dev-js-client:latest"
+          }
+        }
+      }
+    },
+    "moq-dev-rs": {
+      "name": "moq (moq-dev)",
+      "organization": "Luke Curley",
+      "repository": "https://github.com/moq-dev/moq",
+      "draft_versions": [
+        "draft-14",
+        "draft-15",
+        "draft-16",
+        "draft-17"
+      ],
+      "notes": "Rust implementation by kixelated, supports moq-lite and IETF MoQT. Supports multiple draft versions via version negotiation.",
+      "roles": {
+        "relay": {
+          "docker": {
+            "image": "moq-dev-rs-interop:latest",
+            "build": {
+              "dockerfile": "adapters/moq-dev-rs/Dockerfile.relay",
+              "context": "adapters/moq-dev-rs"
+            },
+            "upstream_image": "docker.io/kixelated/moq-relay",
+            "notes": "Adapter wraps upstream image with /certs convention"
+          },
+          "remote": [
+            {
+              "url": "https://cdn.moq.dev/anon",
+              "transport": "webtransport",
+              "notes": "Public relay"
+            }
+          ]
+        },
+        "client": {
+          "docker": {
+            "image": "ghcr.io/englishm/moq-interop-runner-moq-dev-rs-client:latest",
+            "notes": "Pre-built on GHCR. To build from source: ./builds/moq-dev-rs/build.sh && docker tag moq-dev-rs-client:latest ghcr.io/englishm/moq-interop-runner-moq-dev-rs-client:latest"
+          }
+        }
+      }
+    },
     "moq-rs": {
       "name": "moq-rs",
       "organization": "Cloudflare",
       "repository": "https://github.com/cloudflare/moq-rs",
-      "draft_versions": ["draft-14"],
+      "draft_versions": [
+        "draft-14"
+      ],
       "notes": "Rust implementation. Test client reference implementation.",
       "roles": {
         "relay": {
@@ -39,12 +166,13 @@
         }
       }
     },
-
     "moq-rs-draft-16": {
       "name": "moq-rs (draft-16)",
       "organization": "Cloudflare",
       "repository": "https://github.com/itzmanish/moq-rs",
-      "draft_versions": ["draft-16"],
+      "draft_versions": [
+        "draft-16"
+      ],
       "notes": "Rust implementation. Draft-16 branch from itzmanish (Manish Pandit), based on https://github.com/cloudflare/moq-rs/pull/131.",
       "roles": {
         "relay": {
@@ -73,52 +201,78 @@
         }
       }
     },
-
-    "moxygen": {
-      "name": "moxygen",
-      "organization": "Meta",
-      "repository": "https://github.com/facebookexperimental/moxygen",
-      "draft_versions": ["draft-14", "draft-16"],
-      "notes": "C++ implementation. Supports multiple draft versions simultaneously via version negotiation.",
+    "moqlivemock": {
+      "name": "moqlivemock",
+      "organization": "Eyevinn",
+      "repository": "https://github.com/Eyevinn/moqlivemock",
+      "draft_versions": [
+        "draft-14",
+        "draft-16"
+      ],
+      "notes": "Go implementation. Test client and live CMAF publisher. Publisher announces the moq-test/interop namespace for interop testing.",
       "roles": {
-        "relay": {
-          "docker": {
-            "image": "moxygen-interop:latest",
-            "build": {
-              "dockerfile": "adapters/moxygen/Dockerfile.relay",
-              "context": "adapters/moxygen"
-            },
-            "upstream_image": "ghcr.io/facebookexperimental/moqrelay:latest-amd64",
-            "notes": "Adapter wraps upstream image with /certs convention"
-          },
-          "remote": [
-            {
-              "url": "https://fb.mvfst.net:9448/moq-relay",
-              "transport": "webtransport",
-              "tls_disable_verify": true,
-              "notes": "WebTransport endpoint"
-            },
-            {
-              "url": "moqt://fb.mvfst.net:9448",
-              "transport": "quic",
-              "tls_disable_verify": true,
-              "notes": "Raw QUIC endpoint"
-            }
-          ]
-        },
         "client": {
           "docker": {
-            "image": "ghcr.io/facebookexperimental/moxygen-interop-client:latest-amd64"
+            "image": "ghcr.io/eyevinn/mlmtest:latest",
+            "notes": "Published from Eyevinn/moqlivemock CI. Supports RELAY_URL, TESTCASE, TLS_DISABLE_VERIFY, DRAFT env vars."
           }
+        },
+        "publisher": {
+          "remote": [
+            {
+              "url": "https://moqlivemock.demo.osaas.io:443/moq",
+              "transport": "webtransport",
+              "notes": "Live CMAF publisher (video + audio + subtitles)"
+            },
+            {
+              "url": "moqt://moqlivemock.demo.osaas.io:443",
+              "transport": "quic",
+              "notes": "Live CMAF publisher (video + audio + subtitles)"
+            }
+          ]
         }
       }
     },
-
+    "moqtail": {
+      "name": "moqtail",
+      "organization": "OzU",
+      "repository": "https://github.com/moqtail/moqtail",
+      "draft_versions": [
+        "draft-14"
+      ],
+      "notes": "Rust implementation.",
+      "roles": {
+        "relay": {
+          "remote": [
+            {
+              "url": "https://relay.moqtail.dev",
+              "transport": "webtransport"
+            }
+          ]
+        }
+      }
+    },
+    "moqtransport": {
+      "name": "moqtransport",
+      "organization": "Mathis Engelbart (TUM)",
+      "repository": "https://github.com/mengelbart/moqtransport",
+      "draft_versions": [
+        "draft-13"
+      ],
+      "notes": "Go implementation. No persistent public relay.",
+      "roles": {
+        "relay": {}
+      }
+    },
     "moqx": {
       "name": "moqx",
       "organization": "OpenMOQ",
       "repository": "https://github.com/openmoq/moqx",
-      "draft_versions": ["draft-14", "draft-15", "draft-16"],
+      "draft_versions": [
+        "draft-14",
+        "draft-15",
+        "draft-16"
+      ],
       "notes": "C++ relay built on moxygen. Supports multiple draft versions via version negotiation.",
       "roles": {
         "relay": {
@@ -165,73 +319,55 @@
         }
       }
     },
-
-    "moq-dev-rs": {
-      "name": "moq (moq-dev)",
-      "organization": "Luke Curley",
-      "repository": "https://github.com/moq-dev/moq",
-      "draft_versions": ["draft-14", "draft-15", "draft-16", "draft-17"],
-      "notes": "Rust implementation by kixelated, supports moq-lite and IETF MoQT. Supports multiple draft versions via version negotiation.",
+    "moxygen": {
+      "name": "moxygen",
+      "organization": "Meta",
+      "repository": "https://github.com/facebookexperimental/moxygen",
+      "draft_versions": [
+        "draft-14",
+        "draft-16"
+      ],
+      "notes": "C++ implementation. Supports multiple draft versions simultaneously via version negotiation.",
       "roles": {
         "relay": {
           "docker": {
-            "image": "moq-dev-rs-interop:latest",
+            "image": "moxygen-interop:latest",
             "build": {
-              "dockerfile": "adapters/moq-dev-rs/Dockerfile.relay",
-              "context": "adapters/moq-dev-rs"
+              "dockerfile": "adapters/moxygen/Dockerfile.relay",
+              "context": "adapters/moxygen"
             },
-            "upstream_image": "docker.io/kixelated/moq-relay",
+            "upstream_image": "ghcr.io/facebookexperimental/moqrelay:latest-amd64",
             "notes": "Adapter wraps upstream image with /certs convention"
           },
           "remote": [
             {
-              "url": "https://cdn.moq.dev/anon",
+              "url": "https://fb.mvfst.net:9448/moq-relay",
               "transport": "webtransport",
-              "notes": "Public relay"
+              "tls_disable_verify": true,
+              "notes": "WebTransport endpoint"
+            },
+            {
+              "url": "moqt://fb.mvfst.net:9448",
+              "transport": "quic",
+              "tls_disable_verify": true,
+              "notes": "Raw QUIC endpoint"
             }
           ]
         },
         "client": {
           "docker": {
-            "image": "ghcr.io/englishm/moq-interop-runner-moq-dev-rs-client:latest",
-            "notes": "Pre-built on GHCR. To build from source: ./builds/moq-dev-rs/build.sh && docker tag moq-dev-rs-client:latest ghcr.io/englishm/moq-interop-runner-moq-dev-rs-client:latest"
+            "image": "ghcr.io/facebookexperimental/moxygen-interop-client:latest-amd64"
           }
         }
       }
     },
-
-    "moq-dev-js": {
-      "name": "moq (moq-dev, JS)",
-      "organization": "Luke Curley",
-      "repository": "https://github.com/moq-dev/moq",
-      "draft_versions": ["draft-14", "draft-15", "draft-16", "draft-17"],
-      "notes": "Bun/TypeScript test client using @moq/lite npm package with @moq/web-transport polyfill. Supports multiple draft versions via version negotiation.",
-      "roles": {
-        "client": {
-          "docker": {
-            "image": "ghcr.io/englishm/moq-interop-runner-moq-dev-js-client:latest",
-            "notes": "Pre-built on GHCR. To build from source: ./builds/moq-dev-js/build.sh && docker tag moq-dev-js-client:latest ghcr.io/englishm/moq-interop-runner-moq-dev-js-client:latest"
-          }
-        }
-      }
-    },
-
-    "moqtransport": {
-      "name": "moqtransport",
-      "organization": "Mathis Engelbart (TUM)",
-      "repository": "https://github.com/mengelbart/moqtransport",
-      "draft_versions": ["draft-13"],
-      "notes": "Go implementation. No persistent public relay.",
-      "roles": {
-        "relay": {}
-      }
-    },
-
     "quiche-moq": {
       "name": "quiche-moq",
       "organization": "Google",
       "repository": "https://github.com/google/quiche",
-      "draft_versions": ["draft-16"],
+      "draft_versions": [
+        "draft-16"
+      ],
       "notes": "C++ implementation",
       "roles": {
         "relay": {
@@ -248,108 +384,13 @@
         }
       }
     },
-
-    "moqtail": {
-      "name": "moqtail",
-      "organization": "OzU",
-      "repository": "https://github.com/moqtail/moqtail",
-      "draft_versions": ["draft-14"],
-      "notes": "Rust implementation.",
-      "roles": {
-        "relay": {
-          "remote": [
-            {
-              "url": "https://relay.moqtail.dev",
-              "transport": "webtransport"
-            }
-          ]
-        }
-      }
-    },
-
-    "imquic": {
-      "name": "imquic",
-      "organization": "Meetecho",
-      "repository": "https://github.com/meetecho/imquic",
-      "draft_versions": ["draft-17", "draft-16"],
-      "notes": "C implementation. Supports draft-17 and draft-16 via negotiation. Versions below draft-16 were dropped when draft-17 support was added (March 2026).",
-      "roles": {
-        "relay": {
-          "remote": [
-            {
-              "url": "https://lminiero.it:9000",
-              "transport": "webtransport"
-            },
-            {
-              "url": "moqt://lminiero.it:9000",
-              "transport": "quic"
-            }
-          ]
-        }
-      }
-    },
-
-    "libquicr": {
-      "name": "libquicr",
-      "organization": "Cisco",
-      "repository": "https://github.com/Quicr/libquicr",
-      "draft_versions": ["draft-14"],
-      "notes": "C++ implementation",
-      "roles": {
-        "relay": {
-          "remote": [
-            {
-              "url": "https://us-west-2.relay.quicr.org:33437/relay",
-              "transport": "webtransport",
-              "tls_disable_verify": true,
-              "notes": "WebTransport endpoint"
-            },
-            {
-              "url": "moqt://us-west-2.relay.quicr.org:33437",
-              "transport": "quic",
-              "tls_disable_verify": true,
-              "notes": "Raw QUIC endpoint"
-            }
-          ]
-        }
-      }
-    },
-
-    "moqlivemock": {
-      "name": "moqlivemock",
-      "organization": "Eyevinn",
-      "repository": "https://github.com/Eyevinn/moqlivemock",
-      "draft_versions": ["draft-14", "draft-16"],
-      "notes": "Go implementation. Test client and live CMAF publisher. Publisher announces the moq-test/interop namespace for interop testing.",
-      "roles": {
-        "client": {
-          "docker": {
-            "image": "ghcr.io/eyevinn/mlmtest:latest",
-            "notes": "Published from Eyevinn/moqlivemock CI. Supports RELAY_URL, TESTCASE, TLS_DISABLE_VERIFY, DRAFT env vars."
-          }
-        },
-        "publisher": {
-          "remote": [
-            {
-              "url": "https://moqlivemock.demo.osaas.io:443/moq",
-              "transport": "webtransport",
-              "notes": "Live CMAF publisher (video + audio + subtitles)"
-            },
-            {
-              "url": "moqt://moqlivemock.demo.osaas.io:443",
-              "transport": "quic",
-              "notes": "Live CMAF publisher (video + audio + subtitles)"
-            }
-          ]
-        }
-      }
-    },
-
     "xquic": {
       "name": "xquic",
       "organization": "Alibaba",
       "repository": "https://github.com/alibaba/xquic",
-      "draft_versions": ["draft-14"],
+      "draft_versions": [
+        "draft-14"
+      ],
       "notes": "C implementation. Raw QUIC transport only (moqt://).",
       "roles": {
         "relay": {
@@ -366,25 +407,8 @@
           }
         }
       }
-    },
-
-    "aiomoqt": {
-      "name": "aiomoqt",
-      "organization": "MarzResearch",
-      "repository": "https://github.com/gmarzot/aiomoqt",
-      "draft_versions": ["draft-14", "draft-16"],
-      "notes": "Python asyncio implementation of MoQT. Supports draft-14 and draft-16 via version negotiation.",
-      "roles": {
-        "client": {
-          "docker": {
-            "image": "ghcr.io/gmarzot/aiomoqt:latest",
-            "notes": "Pre-built on GHCR from the upstream repo (see Dockerfile at the repo root). Available in :latest and :<version> tags."
-          }
-        }
-      }
     }
   },
-
   "_comment_how_to_add": [
     "To add a new implementation:",
     "1. Add a new key under 'implementations' with a unique ID",


### PR DESCRIPTION
Reorder the implementations so that they are ordered by name. This would avoid conflicts when new implementations are added and also make it easier to see all implementations in a logical order.