### PR TITLE
Add moq-rs-draft-18: Cloudflare draft-18-dev relay

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -212,6 +212,31 @@
         }
       }
     },
+
+    "moq-rs-draft-18": {
+      "name": "moq-rs (draft-18)",
+      "organization": "Cloudflare",
+      "repository": "https://github.com/cloudflare/moq-rs",
+      "draft_versions": ["draft-18"],
+      "notes": "Rust implementation. Deployed as a single instance relay for interop testing, tracking the draft-18-dev branch.",
+      "roles": {
+        "relay": {
+          "remote": [
+            {
+              "url": "moqt://draft-18-interop.cloudflare.mediaoverquic.com:443",
+              "transport": "quic",
+              "notes": "Raw QUIC endpoint"
+            },
+            {
+              "url": "https://draft-18-interop.cloudflare.mediaoverquic.com:443/moq",
+              "transport": "webtransport",
+              "notes": "WebTransport endpoint"
+            }
+          ]
+        }
+      }
+    },
+
     "moqlivemock": {
       "name": "moqlivemock",
       "organization": "Eyevinn",
@@ -300,6 +325,7 @@
         }
       }
     },
+
     "moqx": {
       "name": "moqx",
       "organization": "OpenMOQ",
@@ -355,6 +381,7 @@
         }
       }
     },
+
     "moxygen": {
       "name": "moxygen",
       "organization": "Meta",


### PR DESCRIPTION
Adds a new implementation entry for the `cloudflare/moq-rs` `draft-18-dev` branch, deployed as single instance relay for interop testing.

**Relay endpoint (WebTransport or raw QUIC):**
- `moqt://draft-18-interop.cloudflare.mediaoverquic.com:443`

**Notes:**
- Tracks branch tip; auto-updates
- Remote-only for now (no Docker image yet)