### PR TITLE
Add Docker build support for moq-rs draft-18

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -19,6 +19,8 @@ on:
           - xquic-client
           - imquic-relay
           - imquic-client
+          - moq-rs-draft-18-relay
+          - moq-rs-draft-18-client
       ref:
         description: 'Git ref for source builds (branch/tag/commit). Ignored for adapters.'
         required: false
@@ -118,7 +120,23 @@ jobs:
               echo "ref=" >> "$GITHUB_OUTPUT"
               echo "build_command=./builds/imquic/build.sh --target client" >> "$GITHUB_OUTPUT"
               echo 'images=[{"local":"imquic-moq-interop-test:latest","ghcr":"ghcr.io/englishm/moq-interop-runner-imquic-moq-interop-test"}]' >> "$GITHUB_OUTPUT"
-              ;;  
+              ;;
+            moq-rs-draft-18-relay)
+              REF="${{ inputs.ref }}"
+              REF="${REF:-draft-18-dev}"
+              echo "build_type=build" >> "$GITHUB_OUTPUT"
+              echo "ref=$REF" >> "$GITHUB_OUTPUT"
+              echo "build_command=./builds/moq-rs-draft-18/build.sh --ref $REF --target relay" >> "$GITHUB_OUTPUT"
+              echo 'images=[{"local":"moq-relay-ietf:latest","ghcr":"ghcr.io/englishm/moq-interop-runner-moq-relay-ietf-draft-18"}]' >> "$GITHUB_OUTPUT"
+              ;;
+            moq-rs-draft-18-client)
+              REF="${{ inputs.ref }}"
+              REF="${REF:-draft-18-dev}"
+              echo "build_type=build" >> "$GITHUB_OUTPUT"
+              echo "ref=$REF" >> "$GITHUB_OUTPUT"
+              echo "build_command=./builds/moq-rs-draft-18/build.sh --ref $REF --target client" >> "$GITHUB_OUTPUT"
+              echo 'images=[{"local":"moq-test-client:latest","ghcr":"ghcr.io/englishm/moq-interop-runner-moq-test-client-draft-18"}]' >> "$GITHUB_OUTPUT"
+              ;;
             *)
               echo "::error::Unknown implementation: $IMPL"
               exit 1
@@ -143,6 +161,7 @@ jobs:
             moq-dev-js-client)      IMPL_DIR="builds/moq-dev-js" ;;
             xquic-relay|xquic-client) IMPL_DIR="builds/xquic" ;;
             imquic-relay|imquic-client) IMPL_DIR="builds/imquic" ;;
+            moq-rs-draft-18-relay|moq-rs-draft-18-client) IMPL_DIR="builds/moq-rs-draft-18" ;;
           esac
 
           if [[ -f "$IMPL_DIR/.last-build.json" ]]; then

--- a/builds/moq-rs-draft-18/Dockerfile.client
+++ b/builds/moq-rs-draft-18/Dockerfile.client
@@ -1,0 +1,71 @@
+# syntax=docker/dockerfile:1
+# Dockerfile for moq-test-client
+#
+# This Dockerfile is used by the moq-interop-runner builds framework.
+# It expects to be run with the moq-rs repository root as the build context.
+#
+# Usage (via build.sh):
+#   ./builds/moq-rs/build.sh --target client
+#   ./builds/moq-rs/build.sh --local ~/git/moq-rs --target client
+#
+# If your network uses TLS inspection, place your CA certificate at
+# builds/moq-rs/extra-ca.pem and it will be trusted during the build.
+
+FROM rust:1.87-bookworm AS builder
+
+# Support for networks with TLS inspection - trust additional CA if provided
+RUN --mount=type=secret,id=ca_cert,target=/tmp/extra-ca.pem \
+    if [ -f /tmp/extra-ca.pem ]; then \
+      cat /tmp/extra-ca.pem >> /etc/ssl/certs/ca-certificates.crt && \
+      echo "Added extra CA certificate"; \
+    fi
+
+WORKDIR /build
+
+# Copy workspace files
+COPY Cargo.toml Cargo.lock ./
+COPY moq-transport ./moq-transport
+COPY moq-relay-ietf ./moq-relay-ietf
+COPY moq-native-ietf ./moq-native-ietf
+COPY moq-api ./moq-api
+COPY moq-pub ./moq-pub
+COPY moq-sub ./moq-sub
+COPY moq-clock-ietf ./moq-clock-ietf
+COPY moq-catalog ./moq-catalog
+COPY moq-test-client ./moq-test-client
+
+# Build release binary
+RUN --mount=type=secret,id=ca_cert,target=/tmp/extra-ca.pem \
+    if [ -f /tmp/extra-ca.pem ]; then \
+      cat /tmp/extra-ca.pem >> /etc/ssl/certs/ca-certificates.crt; \
+    fi && \
+    cargo build --release --bin moq-test-client
+
+# Runtime image
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy binary
+COPY --from=builder /build/target/release/moq-test-client /app/moq-test-client
+
+# Copy entrypoint script (maintained separately for linting and testing)
+# Note: This file is part of the moq-interop-runner builds, not the moq-rs source
+COPY entrypoint-client.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+# Create mlog directory
+RUN mkdir -p /mlog
+
+# Environment variables with defaults
+ENV RELAY_URL=https://relay:4443
+ENV TLS_DISABLE_VERIFY=0
+
+RUN useradd -r -u 1000 -g nogroup moq
+USER moq
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/builds/moq-rs-draft-18/Dockerfile.relay
+++ b/builds/moq-rs-draft-18/Dockerfile.relay
@@ -1,0 +1,79 @@
+# syntax=docker/dockerfile:1
+# Dockerfile for moq-relay-ietf
+#
+# This Dockerfile is used by the moq-interop-runner builds framework.
+# It expects to be run with the moq-rs repository root as the build context.
+#
+# Usage (via build.sh):
+#   ./builds/moq-rs/build.sh --target relay
+#   ./builds/moq-rs/build.sh --local ~/git/moq-rs --target relay
+#
+# If your network uses TLS inspection, place your CA certificate at
+# builds/moq-rs/extra-ca.pem and it will be trusted during the build.
+
+FROM rust:1.87-bookworm AS builder
+
+# Support for networks with TLS inspection - trust additional CA if provided
+RUN --mount=type=secret,id=ca_cert,target=/tmp/extra-ca.pem \
+    if [ -f /tmp/extra-ca.pem ]; then \
+      cat /tmp/extra-ca.pem >> /etc/ssl/certs/ca-certificates.crt && \
+      echo "Added extra CA certificate"; \
+    fi
+
+WORKDIR /build
+
+# Copy workspace files
+COPY Cargo.toml Cargo.lock ./
+COPY moq-transport ./moq-transport
+COPY moq-relay-ietf ./moq-relay-ietf
+COPY moq-native-ietf ./moq-native-ietf
+COPY moq-api ./moq-api
+COPY moq-pub ./moq-pub
+COPY moq-sub ./moq-sub
+COPY moq-clock-ietf ./moq-clock-ietf
+COPY moq-catalog ./moq-catalog
+COPY moq-test-client ./moq-test-client
+
+# Build release binary
+RUN --mount=type=secret,id=ca_cert,target=/tmp/extra-ca.pem \
+    if [ -f /tmp/extra-ca.pem ]; then \
+      cat /tmp/extra-ca.pem >> /etc/ssl/certs/ca-certificates.crt; \
+    fi && \
+    cargo build --release --bin moq-relay-ietf
+
+# Runtime image
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    iproute2 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy binary
+COPY --from=builder /build/target/release/moq-relay-ietf /app/moq-relay-ietf
+
+# Copy entrypoint script (maintained separately for linting and testing)
+# Note: This file is part of the moq-interop-runner builds, not the moq-rs source
+COPY entrypoint-relay.sh /app/run_endpoint.sh
+RUN chmod +x /app/run_endpoint.sh
+
+# Create directories for mounts
+RUN mkdir -p /mlog /certs
+
+# Environment variables (following QUIC interop runner conventions)
+ENV MOQT_ROLE=relay
+ENV MOQT_PORT=4443
+
+EXPOSE 4443/udp
+
+# Healthcheck verifies the relay is listening on the configured port
+# Uses shell form to enable environment variable expansion at runtime
+HEALTHCHECK --interval=5s --timeout=3s --start-period=5s \
+  CMD sh -c 'ss -uln | grep -q ":${MOQT_PORT:-4443}" || exit 1'
+
+RUN useradd -r -u 1000 -g nogroup moq
+USER moq
+
+ENTRYPOINT ["/app/run_endpoint.sh"]

--- a/builds/moq-rs-draft-18/build.sh
+++ b/builds/moq-rs-draft-18/build.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+# build.sh - Build moq-rs draft-18 Docker images from source
+#
+# Usage:
+#   ./build.sh                      # Clone from default ref (draft-18-dev)
+#   ./build.sh --ref feature-branch # Clone specific branch/tag/commit
+#   ./build.sh --repo URL           # Clone from a different repository (fork)
+#   ./build.sh --local ~/git/moq-rs # Use local checkout
+#   ./build.sh --target relay       # Build only relay image
+#   ./build.sh --target client      # Build only client image
+#
+# This script is designed to be easy to copy/paste for other implementations.
+# Utility functions at the top can be extracted to a shared library.
+
+set -euo pipefail
+
+#############################################################################
+# Configuration (implementation-specific)
+#############################################################################
+
+IMPL_NAME="moq-rs-draft-18"
+REPO_URL="https://github.com/cloudflare/moq-rs"
+DEFAULT_REF="draft-18-dev"
+
+# Build directory (where this script lives)
+BUILD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCES_DIR="${BUILD_DIR}/.sources"
+RUNNER_ROOT="$(cd "${BUILD_DIR}/../.." && pwd)"
+
+#############################################################################
+# Utility Functions (candidates for shared library)
+#############################################################################
+
+log() {
+    echo "[build] $*" >&2
+}
+
+error() {
+    echo "[build] ERROR: $*" >&2
+    exit 1
+}
+
+# Get git commit hash from a directory
+get_git_commit() {
+    local dir="$1"
+    git -C "$dir" rev-parse HEAD 2>/dev/null || echo "unknown"
+}
+
+# Check if git working directory is dirty
+is_git_dirty() {
+    local dir="$1"
+    if git -C "$dir" diff --quiet HEAD 2>/dev/null && \
+       git -C "$dir" diff --cached --quiet HEAD 2>/dev/null; then
+        echo "false"
+    else
+        echo "true"
+    fi
+}
+
+# Get current timestamp in ISO 8601 format
+get_timestamp() {
+    date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+#############################################################################
+# Argument Parsing
+#############################################################################
+
+REPO="$REPO_URL"
+REF="$DEFAULT_REF"
+LOCAL_PATH=""
+TARGET="all"  # all | relay | client
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)
+            REPO="$2"
+            shift 2
+            ;;
+        --ref)
+            REF="$2"
+            shift 2
+            ;;
+        --local)
+            LOCAL_PATH="$2"
+            shift 2
+            ;;
+        --target)
+            TARGET="$2"
+            shift 2
+            ;;
+        *)
+            error "Unknown argument: $1"
+            ;;
+    esac
+done
+
+#############################################################################
+# Source Preparation
+#############################################################################
+
+SOURCE_DIR="${SOURCES_DIR}/${IMPL_NAME}"
+SOURCE_INFO=""
+
+if [[ -n "$LOCAL_PATH" ]]; then
+    log "Using local checkout: $LOCAL_PATH"
+    SOURCE_DIR="$LOCAL_PATH"
+    COMMIT=$(get_git_commit "$SOURCE_DIR")
+    DIRTY=$(is_git_dirty "$SOURCE_DIR")
+    SOURCE_INFO="local:$LOCAL_PATH commit:${COMMIT:0:7} dirty:$DIRTY"
+else
+    log "Cloning $REPO at ref $REF..."
+    mkdir -p "$SOURCES_DIR"
+    rm -rf "$SOURCE_DIR"
+    git clone --depth=1 --branch "$REF" "$REPO" "$SOURCE_DIR"
+    COMMIT=$(get_git_commit "$SOURCE_DIR")
+    SOURCE_INFO="repo:$REPO ref:$REF commit:${COMMIT:0:7}"
+    log "Cloned at commit $COMMIT"
+fi
+
+#############################################################################
+# Build
+#############################################################################
+
+# We use docker build -f <dockerfile> <context> to keep Dockerfiles in the
+# interop-runner repo while using the source repo as the build context.
+# This avoids polluting local checkouts with extra files.
+#
+# If your network uses TLS inspection, place your CA certificate at
+# builds/moq-rs-draft-18/extra-ca.pem and it will be trusted during the build.
+
+build_target() {
+    local target="$1"
+    local image_name=""
+    local entrypoint_script=""
+
+    case "$target" in
+        relay)
+            dockerfile="${BUILD_DIR}/Dockerfile.relay"
+            image_name="moq-relay-ietf"
+            entrypoint_script="${BUILD_DIR}/entrypoint-relay.sh"
+            ;;
+        client)
+            dockerfile="${BUILD_DIR}/Dockerfile.client"
+            image_name="moq-test-client"
+            entrypoint_script="${BUILD_DIR}/entrypoint-client.sh"
+            ;;
+        *)
+            error "Unknown target: $target"
+            ;;
+    esac
+
+    log "Building $image_name from $SOURCE_DIR..."
+
+    # Build args
+    local -a build_args=(
+        "build"
+        "-f" "$dockerfile"
+        "-t" "${image_name}:latest"
+    )
+
+    # Add extra CA cert if present
+    if [[ -f "${BUILD_DIR}/extra-ca.pem" ]]; then
+        log "Using extra CA certificate"
+        build_args+=("--secret" "id=ca_cert,src=${BUILD_DIR}/extra-ca.pem")
+    fi
+
+    # Copy entrypoint into source dir temporarily (needed as Docker build context file)
+    cp "$entrypoint_script" "${SOURCE_DIR}/$(basename "$entrypoint_script")"
+
+    build_args+=("$SOURCE_DIR")
+
+    docker "${build_args[@]}"
+
+    # Clean up copied entrypoint
+    rm -f "${SOURCE_DIR}/$(basename "$entrypoint_script")"
+
+    log "Built ${image_name}:latest"
+
+    # Write build metadata
+    TIMESTAMP=$(get_timestamp)
+    cat > "${BUILD_DIR}/.last-build.json" << EOF
+{
+  "implementation": "${IMPL_NAME}",
+  "target": "${target}",
+  "image": "${image_name}:latest",
+  "built_at": "${TIMESTAMP}",
+  "source": {
+    "info": "${SOURCE_INFO}",
+    "commit": "${COMMIT:-unknown}"
+  }
+}
+EOF
+}
+
+case "$TARGET" in
+    relay)
+        build_target relay
+        ;;
+    client)
+        build_target client
+        ;;
+    all)
+        build_target relay
+        build_target client
+        ;;
+    *)
+        error "Unknown target: $TARGET (must be relay, client, or all)"
+        ;;
+esac
+
+log "Done."

--- a/builds/moq-rs-draft-18/config.json
+++ b/builds/moq-rs-draft-18/config.json
@@ -1,0 +1,18 @@
+{
+  "name": "moq-rs-draft-18",
+  "description": "Cloudflare's Rust MoQT implementation (draft-18-dev branch)",
+  "repository": "https://github.com/cloudflare/moq-rs",
+  "default_ref": "draft-18-dev",
+  "targets": {
+    "relay": {
+      "dockerfile": "Dockerfile.relay",
+      "image_name": "moq-relay-ietf",
+      "context": ".sources/moq-rs-draft-18"
+    },
+    "client": {
+      "dockerfile": "Dockerfile.client",
+      "image_name": "moq-test-client",
+      "context": ".sources/moq-rs-draft-18"
+    }
+  }
+}

--- a/builds/moq-rs-draft-18/entrypoint-client.sh
+++ b/builds/moq-rs-draft-18/entrypoint-client.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# entrypoint-client.sh - Wrapper script for moq-test-client
+# Translates standard MoQT interop environment variables to moq-test-client CLI
+#
+# Expected environment:
+#   RELAY_URL          - URL of relay to test against (required)
+#   TESTCASE           - Specific test case to run (optional, runs all if not set)
+#   TLS_DISABLE_VERIFY - Set to 1 or true to disable TLS verification
+#   VERBOSE            - Set to 1 or true for verbose output
+#
+# Exit codes:
+#   0 - All tests passed
+#   1 - One or more tests failed
+
+set -euo pipefail
+
+# Build command line arguments from environment variables
+declare -a ARGS=()
+
+if [ -n "${RELAY_URL:-}" ]; then
+    ARGS+=("--relay" "$RELAY_URL")
+fi
+
+if [ -n "${TESTCASE:-}" ]; then
+    ARGS+=("--test" "$TESTCASE")
+fi
+
+if [ "${TLS_DISABLE_VERIFY:-}" = "1" ] || [ "${TLS_DISABLE_VERIFY:-}" = "true" ]; then
+    ARGS+=("--tls-disable-verify")
+fi
+
+if [ "${VERBOSE:-}" = "1" ] || [ "${VERBOSE:-}" = "true" ]; then
+    ARGS+=("--verbose")
+fi
+
+# Use ${ARGS[@]+"${ARGS[@]}"} for safe empty array handling
+exec /app/moq-test-client ${ARGS[@]+"${ARGS[@]}"}

--- a/builds/moq-rs-draft-18/entrypoint-relay.sh
+++ b/builds/moq-rs-draft-18/entrypoint-relay.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# entrypoint-relay.sh - Wrapper script for moq-rs relay
+# Translates standard MoQT interop environment variables to moq-relay-ietf CLI
+#
+# Expected environment:
+#   MOQT_ROLE     - Role to run: relay (required, only relay supported)
+#   MOQT_PORT     - Port to listen on (default: 4443)
+#   MOQT_CERT     - Path to TLS certificate (default: /certs/cert.pem)
+#   MOQT_KEY      - Path to TLS private key (default: /certs/priv.key)
+#   MOQT_MLOG_DIR - Directory for mlog files (default: /mlog)
+#
+# Expected mounts:
+#   /certs/cert.pem - TLS certificate
+#   /certs/priv.key - TLS private key
+#
+# Exit codes:
+#   0   - Clean shutdown
+#   1   - Configuration error
+#   127 - Unsupported role
+
+set -euo pipefail
+
+ROLE="${MOQT_ROLE:-relay}"
+PORT="${MOQT_PORT:-4443}"
+CERT="${MOQT_CERT:-/certs/cert.pem}"
+KEY="${MOQT_KEY:-/certs/priv.key}"
+MLOG_DIR="${MOQT_MLOG_DIR:-/mlog}"
+
+case "$ROLE" in
+  relay)
+    echo "Starting moq-rs relay on port $PORT"
+    echo "  Cert: $CERT"
+    echo "  Key:  $KEY"
+    echo "  Mlog: $MLOG_DIR"
+
+    if [ ! -f "$CERT" ]; then
+      echo "ERROR: Certificate not found at $CERT" >&2
+      echo "Make sure /certs is mounted with cert.pem and priv.key" >&2
+      exit 1
+    fi
+    if [ ! -f "$KEY" ]; then
+      echo "ERROR: Private key not found at $KEY" >&2
+      exit 1
+    fi
+
+    exec /app/moq-relay-ietf \
+      --bind "0.0.0.0:$PORT" \
+      --tls-cert "$CERT" \
+      --tls-key "$KEY" \
+      --mlog-dir "$MLOG_DIR"
+    ;;
+
+  *)
+    echo "Role '$ROLE' not supported by moq-rs adapter" >&2
+    echo "Supported roles: relay" >&2
+    exit 127
+    ;;
+esac

--- a/implementations.json
+++ b/implementations.json
@@ -221,6 +221,10 @@
       "notes": "Rust implementation. Deployed as a single instance relay for interop testing, tracking the draft-18-dev branch.",
       "roles": {
         "relay": {
+          "docker": {
+            "image": "ghcr.io/englishm/moq-interop-runner-moq-relay-ietf-draft-18:latest",
+            "notes": "Pre-built on GHCR. To build from source: ./builds/moq-rs-draft-18/build.sh --target relay && docker tag moq-relay-ietf:latest ghcr.io/englishm/moq-interop-runner-moq-relay-ietf-draft-18:latest"
+          },
           "remote": [
             {
               "url": "moqt://draft-18-interop.cloudflare.mediaoverquic.com:443",
@@ -233,6 +237,12 @@
               "notes": "WebTransport endpoint"
             }
           ]
+        },
+        "client": {
+          "docker": {
+            "image": "ghcr.io/englishm/moq-interop-runner-moq-test-client-draft-18:latest",
+            "notes": "Pre-built on GHCR. To build from source: ./builds/moq-rs-draft-18/build.sh --target client && docker tag moq-test-client:latest ghcr.io/englishm/moq-interop-runner-moq-test-client-draft-18:latest"
+          }
         }
       }
     },


### PR DESCRIPTION
Follow-up to #81. Adds Docker image build support for the moq-rs draft-18 implementation.

**New in `builds/moq-rs-draft-18/`:**
- `build.sh` — builds relay and client images from `cloudflare/moq-rs@draft-18-dev` (default ref, overridable)
- `Dockerfile.relay`, `Dockerfile.client`, `entrypoint-relay.sh`, `entrypoint-client.sh` — same structure as `builds/moq-rs/`

**GHCR image names:**
- `ghcr.io/englishm/moq-interop-runner-moq-relay-ietf-draft-18`
- `ghcr.io/englishm/moq-interop-runner-moq-test-client-draft-18`

**`build-images.yml`:** adds `moq-rs-draft-18-relay` and `moq-rs-draft-18-client` as workflow dispatch options.

**`implementations.json`:** adds `docker` entries to `moq-rs-draft-18` for both relay and client roles.

Note: images won't appear in GHCR until the workflow is run manually for each target.