### PR TITLE
Update moq-dev clients to latest; fix moq-dev-js local interop

### DIFF
--- a/adapters/moq-dev-rs/Dockerfile.relay
+++ b/adapters/moq-dev-rs/Dockerfile.relay
@@ -12,7 +12,7 @@
 # Usage:
 #   docker run -v ./certs:/certs -p 4443:4443/udp moq-dev-rs-interop:latest
 
-FROM docker.io/kixelated/moq-relay
+FROM docker.io/moqdev/moq-relay
 
 # Map our /certs convention to moq-relay's expected env vars
 ENV MOQ_SERVER_BIND=[::]:4443

--- a/builds/moq-dev-js/Dockerfile.client
+++ b/builds/moq-dev-js/Dockerfile.client
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # Dockerfile for moq-dev-js-client (Bun/TypeScript)
 #
-# Builds a test client using @moq/lite with a WebTransport polyfill.
+# Builds a test client using @moq/net with a WebTransport polyfill.
 #
 # Usage:
 #   docker build -t moq-dev-js-client:latest -f Dockerfile.client .

--- a/builds/moq-dev-js/bun.lock
+++ b/builds/moq-dev-js/bun.lock
@@ -4,19 +4,16 @@
     "": {
       "name": "moq-dev-js-client",
       "dependencies": {
-        "@fails-components/webtransport": "latest",
-        "@fails-components/webtransport-transport-http3-quiche": "latest",
-        "@moq/lite": "0.1.3",
+        "@moq/net": "0.1.2",
+        "@moq/web-transport": "0.1.2",
       },
       "devDependencies": {
         "@biomejs/biome": "latest",
         "@types/bun": "^1.3.9",
+        "@types/node": "^22",
       },
     },
   },
-  "trustedDependencies": [
-    "@fails-components/webtransport-transport-http3-quiche",
-  ],
   "packages": {
     "@biomejs/biome": ["@biomejs/biome@2.3.14", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.14", "@biomejs/cli-darwin-x64": "2.3.14", "@biomejs/cli-linux-arm64": "2.3.14", "@biomejs/cli-linux-arm64-musl": "2.3.14", "@biomejs/cli-linux-x64": "2.3.14", "@biomejs/cli-linux-x64-musl": "2.3.14", "@biomejs/cli-win32-arm64": "2.3.14", "@biomejs/cli-win32-x64": "2.3.14" }, "bin": { "biome": "bin/biome" } }, "sha512-QMT6QviX0WqXJCaiqVMiBUCr5WRQ1iFSjvOLoTk6auKukJMvnMzWucXpwZB0e8F00/1/BsS9DzcKgWH+CLqVuA=="],
 
@@ -36,180 +33,40 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-oizCjdyQ3WJEswpb3Chdngeat56rIdSYK12JI3iI11Mt5T5EXcZ7WLuowzEaFPNJ3zmOQFliMN8QY1Pi+qsfdQ=="],
 
-    "@fails-components/webtransport": ["@fails-components/webtransport@1.5.3", "", { "dependencies": { "@types/debug": "^4.1.7", "bindings": "^1.5.0", "debug": "^4.3.4" } }, "sha512-ax+xQPaYm29hSPxEGaFzQkYkpLVsvDjXn3eabn9E0TlESW2y/HRgTIABG73HjypCaHnhDYP8Q6QkN/uWUhQH2A=="],
+    "@moq/net": ["@moq/net@0.1.2", "", { "dependencies": { "@moq/qmux": "^0.0.6", "@moq/signals": "^0.1.7", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-j8Eyu188n06RGWXIoarVFYPTWEq52WhdXVg3S0a3CGpXP0j5t0t2p9kUzUSgShdk4W6ItbvZ30mR+Ihwmuja0Q=="],
 
-    "@fails-components/webtransport-transport-http3-quiche": ["@fails-components/webtransport-transport-http3-quiche@1.5.3", "", { "dependencies": { "@types/debug": "^4.1.7", "bindings": "^1.5.0", "cmake-js": "^8.0.0", "debug": "^4.3.4", "node-addon-api": "^7.0.0", "prebuild-install": "^7.1.1" } }, "sha512-PlR/jYHgEwbv6yQywH5D9czRs+2k05Mcc9/6Uh2b0ShCuOxQcbfPgJ9St9r75AMbKcDVu2Ibm0Lmt3JFCB5HEg=="],
+    "@moq/qmux": ["@moq/qmux@0.0.6", "", {}, "sha512-ISuGz05lUvf1hzHW3Aw3VnsGRJe1w9Qdog3LQ66KS+l+5mzQsPANvW8yOioEe1Z9dJO2G3sAHoGPnzwnsY9SIQ=="],
 
-    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
+    "@moq/signals": ["@moq/signals@0.1.7", "", { "peerDependencies": { "@types/react": "^19.1.8", "react": "^19.0.0", "solid-js": "^1.9.7" }, "optionalPeers": ["@types/react", "react", "solid-js"] }, "sha512-Z45dKktZj1BLviWSXgZmtlePy02jx0H3cYp5+q9aYpDpb9k+v8shpjwBNNuTGxT4PUgxiQQFDY6YpKfLb54Xwg=="],
 
-    "@moq/lite": ["@moq/lite@0.1.3", "", { "dependencies": { "@moq/signals": "^0.1.2", "@moq/web-transport-ws": "^0.1.2", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.1.0" } }, "sha512-yvjtpPO6MWJqXVGhKnr7i/aFO2kbz2IVdACfuJuQYjZyCWQ44OpDrCnUfz6VsioxLGAVANLXDqct8gInmFA/sQ=="],
+    "@moq/web-transport": ["@moq/web-transport@0.1.2", "", { "optionalDependencies": { "@moq/web-transport-darwin-arm64": "0.1.2", "@moq/web-transport-darwin-x64": "0.1.2", "@moq/web-transport-linux-arm64-gnu": "0.1.2", "@moq/web-transport-linux-x64-gnu": "0.1.2", "@moq/web-transport-win32-x64-msvc": "0.1.2" } }, "sha512-cJE0B+T5a8ey1ZgFUIBTWkIWfhCAYGAUgAw8XYeOPsKPjFhtW9M/C+XV8Yu0IeUS4nnrbBPw4sEc+TvMybV4IQ=="],
 
-    "@moq/signals": ["@moq/signals@0.1.2", "", { "dependencies": { "dequal": "^2.0.3" }, "peerDependencies": { "@types/react": "^19.1.8", "react": "^19.0.0", "solid-js": "^1.9.7" }, "optionalPeers": ["react", "solid-js"] }, "sha512-mzDk7KvQLSU6ZjZp9jrK2ZRlq07zp+LFZvS6AbKFyEqOxawwsy4tRAPdK9zmFCfIupjqwia42Pq9upo/RgjrMA=="],
+    "@moq/web-transport-darwin-arm64": ["@moq/web-transport-darwin-arm64@0.1.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-waCy1fIyUg0WDwP+rI5Jg7Mw5efsJjImGZzyIDvCXM98O/nWoybPmh8Cka6VP+8xUBeclRpWmlC6phYXtYqPyw=="],
 
-    "@moq/web-transport-ws": ["@moq/web-transport-ws@0.1.2", "", {}, "sha512-mYha+AkLNPT3uOGnTA5YWjpxc9LO/yriFSoWzKkR0zN3UMZb9RXbsD8Gbhg1pJZod6QD4tevHoOWTBADYN7yAQ=="],
+    "@moq/web-transport-darwin-x64": ["@moq/web-transport-darwin-x64@0.1.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-MWllJfxoZ5ncFxuWpcrwIEMpNjvixt7ycCZQDoW9yjfqsMzfPVRaunvJ8kW0zp0IXrGpC/RFeecFSaE7PmzHpg=="],
+
+    "@moq/web-transport-linux-arm64-gnu": ["@moq/web-transport-linux-arm64-gnu@0.1.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-cjVoLj/SGjetlJx3tbVt0fhzYIN195L9JQ/UkZqpvkhIfWEopPX7MzCWUPRK72mzH7kCyWr0dUGSu7B3pD1j1w=="],
+
+    "@moq/web-transport-linux-x64-gnu": ["@moq/web-transport-linux-x64-gnu@0.1.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ExZbJFdUeL2G0FkBY7mw/tZTq6+lZfYgIWkjDRa4YkifcGjMevEgpsby5QXlxhs+Og1y5q/x2Xgzd/bAG3TkRQ=="],
+
+    "@moq/web-transport-win32-x64-msvc": ["@moq/web-transport-win32-x64-msvc@0.1.2", "", { "os": "win32", "cpu": "x64" }, "sha512-iypZ2WVoqEDB4dt7qG/wRj3zWAEqpoPP1Lj44L3o23g60UGuqsrGgbpy85qmejBkjMmDrWHr0Phx6pYJNAj/TA=="],
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
-    "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
-
-    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
-
-    "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
-
-    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
-
-    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "@types/node": ["@types/node@22.19.21", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA=="],
 
     "async-mutex": ["async-mutex@0.5.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA=="],
 
-    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
-
-    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
-
-    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
-
-    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
-
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
-
-    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
-
-    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
-
-    "cmake-js": ["cmake-js@8.0.0", "", { "dependencies": { "debug": "^4.4.3", "fs-extra": "^11.3.3", "node-api-headers": "^1.8.0", "rc": "1.2.8", "semver": "^7.7.3", "tar": "^7.5.6", "url-join": "^4.0.1", "which": "^6.0.0", "yargs": "^17.7.2" }, "bin": { "cmake-js": "bin/cmake-js" } }, "sha512-YbUP88RDwCvoQkZhRtGURYm9RIpWdtvZuhT87fKNoLjk8kIFIFeARpKfuZQGdwfH99GZpUmqSfcDrK62X7lTgg=="],
-
-    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
-
-    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
-
-    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
-
-    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
-    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
-
-    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
-
-    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
-
-    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
-
-    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
-
-    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
-
-    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
-
-    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
-
-    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
-
-    "fs-extra": ["fs-extra@11.3.3", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg=="],
-
-    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
-
-    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
-
-    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
-
-    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
-
-    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
-
-    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
-
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
-
-    "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
-
-    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
-
-    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
-
-    "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
-
-    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
-
-    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
-
-    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
-    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
-
-    "node-abi": ["node-abi@3.87.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ=="],
-
-    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
-
-    "node-api-headers": ["node-api-headers@1.8.0", "", {}, "sha512-jfnmiKWjRAGbdD1yQS28bknFM1tbHC1oucyuMPjmkEs+kpiu76aRs40WlTmBmyEgzDM76ge1DQ7XJ3R5deiVjQ=="],
-
-    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
-
-    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
-
-    "pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
-
-    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
-
-    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
-
-    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
-
-    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
-
-    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
-    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
-
-    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
-
-    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
-
-    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
-
-    "tar": ["tar@7.5.7", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ=="],
-
-    "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
-
-    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
-
-    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
-    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
-
-    "url-join": ["url-join@4.0.1", "", {}, "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="],
-
-    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
-
-    "which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
-
-    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
-
-    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
-
-    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
-
-    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
-
-    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "tar-fs/chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
+    "bun-types/@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
   }
 }

--- a/builds/moq-dev-js/bun.lock
+++ b/builds/moq-dev-js/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "moq-dev-js-client",
       "dependencies": {
-        "@moq/net": "0.1.2",
+        "@moq/net": "0.1.3",
         "@moq/web-transport": "0.1.2",
       },
       "devDependencies": {
@@ -33,11 +33,11 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
 
-    "@moq/net": ["@moq/net@0.1.2", "", { "dependencies": { "@moq/qmux": "^0.0.6", "@moq/signals": "^0.1.7", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-j8Eyu188n06RGWXIoarVFYPTWEq52WhdXVg3S0a3CGpXP0j5t0t2p9kUzUSgShdk4W6ItbvZ30mR+Ihwmuja0Q=="],
+    "@moq/net": ["@moq/net@0.1.3", "", { "dependencies": { "@moq/qmux": "^0.0.6", "@moq/signals": "^0.1.8", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-OiT5URtjdyirtsVfsDL25GxDzxE0iN0elZygibEQCt0E9fTgIG0HbI9WXBorI1s5jtZbYk0psKnY9h3Vgs7kGw=="],
 
     "@moq/qmux": ["@moq/qmux@0.0.6", "", {}, "sha512-ISuGz05lUvf1hzHW3Aw3VnsGRJe1w9Qdog3LQ66KS+l+5mzQsPANvW8yOioEe1Z9dJO2G3sAHoGPnzwnsY9SIQ=="],
 
-    "@moq/signals": ["@moq/signals@0.1.7", "", { "peerDependencies": { "@types/react": "^19.1.8", "react": "^19.0.0", "solid-js": "^1.9.7" }, "optionalPeers": ["@types/react", "react", "solid-js"] }, "sha512-Z45dKktZj1BLviWSXgZmtlePy02jx0H3cYp5+q9aYpDpb9k+v8shpjwBNNuTGxT4PUgxiQQFDY6YpKfLb54Xwg=="],
+    "@moq/signals": ["@moq/signals@0.1.8", "", { "peerDependencies": { "@types/react": "^19.2.15", "react": "^19.0.0", "solid-js": "^1.9.13" }, "optionalPeers": ["@types/react", "react", "solid-js"] }, "sha512-UUbnyyJATCZBpjRjcZZq0vsA6Dc+HcEhNkUF8/eaR9Vkh9m2XTKPY7Oo4XyNiAoAAfI40+LxlI4QT5vv1KJKWA=="],
 
     "@moq/web-transport": ["@moq/web-transport@0.1.2", "", { "optionalDependencies": { "@moq/web-transport-darwin-arm64": "0.1.2", "@moq/web-transport-darwin-x64": "0.1.2", "@moq/web-transport-linux-arm64-gnu": "0.1.2", "@moq/web-transport-linux-x64-gnu": "0.1.2", "@moq/web-transport-win32-x64-msvc": "0.1.2" } }, "sha512-cJE0B+T5a8ey1ZgFUIBTWkIWfhCAYGAUgAw8XYeOPsKPjFhtW9M/C+XV8Yu0IeUS4nnrbBPw4sEc+TvMybV4IQ=="],
 

--- a/builds/moq-dev-js/config.json
+++ b/builds/moq-dev-js/config.json
@@ -1,6 +1,6 @@
 {
 	"name": "moq-dev-js",
-	"description": "moq-dev JS/TypeScript test client using @moq/lite",
+	"description": "moq-dev JS/TypeScript test client using @moq/net",
 	"repository": "https://github.com/moq-dev/moq",
 	"targets": {
 		"client": {

--- a/builds/moq-dev-js/package.json
+++ b/builds/moq-dev-js/package.json
@@ -8,15 +8,12 @@
 		"fix": "biome check --fix"
 	},
 	"dependencies": {
-		"@moq/lite": "0.1.3",
-		"@fails-components/webtransport": "latest",
-		"@fails-components/webtransport-transport-http3-quiche": "latest"
+		"@moq/net": "0.1.2",
+		"@moq/web-transport": "0.1.2"
 	},
-	"trustedDependencies": [
-		"@fails-components/webtransport-transport-http3-quiche"
-	],
 	"devDependencies": {
 		"@biomejs/biome": "latest",
-		"@types/bun": "^1.3.9"
+		"@types/bun": "^1.3.9",
+		"@types/node": "^22"
 	}
 }

--- a/builds/moq-dev-js/package.json
+++ b/builds/moq-dev-js/package.json
@@ -8,7 +8,7 @@
 		"fix": "biome check --fix"
 	},
 	"dependencies": {
-		"@moq/net": "0.1.2",
+		"@moq/net": "0.1.3",
 		"@moq/web-transport": "0.1.2"
 	},
 	"devDependencies": {

--- a/builds/moq-dev-js/src/main.ts
+++ b/builds/moq-dev-js/src/main.ts
@@ -1,8 +1,10 @@
 // moq-dev-js test client
-// MoQT interop test client using @moq/lite with WebTransport polyfill
+// MoQT interop test client using @moq/net with the @moq/web-transport polyfill
 
-import * as wt from "@fails-components/webtransport";
-import * as Moq from "@moq/lite";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import * as Moq from "@moq/net";
+import { install } from "@moq/web-transport";
 
 // Redirect all console output to stderr so library debug output
 // doesn't corrupt TAP on stdout.
@@ -21,10 +23,9 @@ process.on("unhandledRejection", (err) => {
 	console.error("unhandled rejection:", err);
 });
 
-// Initialize WebTransport polyfill
-// @ts-expect-error - polyfill types don't exactly match the global WebTransport type
-globalThis.WebTransport = wt.WebTransport;
-await wt.quicheLoaded;
+// Install the @moq/web-transport polyfill (QUIC/HTTP3 via a NAPI addon).
+// @moq/net's connect() reads globalThis.WebTransport at call time.
+install();
 
 const TESTS = [
 	"setup-only",
@@ -139,6 +140,30 @@ function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// Path to the relay's TLS certificate, mounted by the interop runner following
+// the QUIC interop convention (/certs/cert.pem). Override with CERT_PATH.
+const CERT_PATH = process.env.CERT_PATH ?? "/certs/cert.pem";
+
+// Compute the SHA-256 of the leaf certificate's DER encoding, suitable for
+// WebTransport `serverCertificateHashes`. Returns undefined if no cert is found.
+function certHash(): Uint8Array<ArrayBuffer> | undefined {
+	let pem: string;
+	try {
+		pem = readFileSync(CERT_PATH, "utf8");
+	} catch {
+		return undefined;
+	}
+
+	// Use only the first (leaf) certificate block.
+	const match = pem.match(
+		/-----BEGIN CERTIFICATE-----([\s\S]*?)-----END CERTIFICATE-----/,
+	);
+	if (!match) return undefined;
+
+	const der = Buffer.from(match[1].replace(/\s+/g, ""), "base64");
+	return new Uint8Array(createHash("sha256").update(der).digest());
+}
+
 // Connect to the relay, returning an established connection
 async function connect(
 	relayUrl: string,
@@ -149,9 +174,18 @@ async function connect(
 	const options: Moq.Connection.ConnectProps = {};
 
 	if (tlsDisableVerify) {
-		// Use http:// scheme to trigger automatic cert fingerprint fetch
-		// or pass serverCertificateHashes if available
-		url.protocol = "http:";
+		// Prefer pinning the mounted self-signed cert via serverCertificateHashes
+		// over https://. This works against any relay using that cert, unlike the
+		// http:// `/certificate.sha256` fingerprint fetch (a moq.dev-only, non-
+		// standard convention). Fall back to that fetch if no cert is mounted.
+		const hash = certHash();
+		if (hash) {
+			options.webtransport = {
+				serverCertificateHashes: [{ algorithm: "sha-256", value: hash }],
+			};
+		} else {
+			url.protocol = "http:";
+		}
 	}
 
 	return await Moq.Connection.connect(url, options);

--- a/builds/moq-dev-js/tsconfig.json
+++ b/builds/moq-dev-js/tsconfig.json
@@ -6,6 +6,10 @@
 		"strict": true,
 		"esModuleInterop": true,
 		"skipLibCheck": true,
+		"types": ["node", "bun"],
+		// @moq/web-transport ships raw .ts sources with explicit .ts import
+		// specifiers; allow them (safe under --noEmit, which `check` uses).
+		"allowImportingTsExtensions": true,
 		"outDir": "dist",
 		"rootDir": "src"
 	},

--- a/builds/moq-dev-rs/Cargo.lock
+++ b/builds/moq-dev-rs/Cargo.lock
@@ -90,9 +90,6 @@ name = "anyhow"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
-dependencies = [
- "backtrace",
-]
 
 [[package]]
 name = "asn1-rs"
@@ -131,18 +128,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -203,9 +188,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -221,12 +206,6 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -263,6 +242,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -342,15 +332,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,10 +357,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
+name = "cpufeatures"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crypto-common"
@@ -506,27 +490,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
-]
-
-[[package]]
 name = "fastbloom"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +520,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +539,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures"
@@ -692,9 +670,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -708,6 +700,15 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -932,6 +933,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,6 +986,26 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1052,10 +1079,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "kio"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32311a076e65af53bebb6ba1d6808aae929453800cbebc12e1fa561624baa808"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1133,6 +1195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1151,55 +1214,56 @@ dependencies = [
 ]
 
 [[package]]
-name = "moq-lite"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8a4c4e66081bc21067488da13f4131540b38b1cb79fb5176ef4ddacd104786b"
-dependencies = [
- "async-channel",
- "bytes",
- "futures",
- "hex",
- "num_enum",
- "rand 0.9.2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-async",
- "web-transport-trait",
-]
-
-[[package]]
 name = "moq-native"
-version = "0.13.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb4afcc28a64901fa8ec24c16f72b022405e87f0cb65323b6c77147879bce75"
+checksum = "7355f59dfbdfb9c5615541ec64427c3d905a6c6dceb0d234748a6ec1d6f5ee9d"
 dependencies = [
- "anyhow",
  "clap",
  "futures",
  "hex",
  "humantime",
  "humantime-serde",
- "moq-lite",
+ "moq-net",
+ "notify",
  "parking_lot",
+ "qmux",
  "quinn",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rcgen",
  "reqwest",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile",
  "rustls-webpki",
  "serde",
  "serde_with",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "url",
  "web-transport-quinn",
- "web-transport-ws",
+]
+
+[[package]]
+name = "moq-net"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe9e894d74a6345c63d320779ffd7611dd17b94e99fb6041f585af3b57ec13c"
+dependencies = [
+ "bytes",
+ "futures",
+ "kio",
+ "num_enum",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-async",
+ "web-transport-trait",
 ]
 
 [[package]]
@@ -1210,6 +1274,33 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1314,12 +1405,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,6 +1482,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,6 +1507,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "qmux"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a761722f4499404d45c4971e332b8d0d1fe4a1882d404c2c5f96f3e49933e9"
+dependencies = [
+ "bytes",
+ "futures",
+ "rustls",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tokio-tungstenite",
+ "tracing",
+ "web-transport-proto",
+ "web-transport-trait",
 ]
 
 [[package]]
@@ -1488,15 +1601,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1504,18 +1612,19 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
+name = "rand"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1530,21 +1639,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rcgen"
@@ -1700,15 +1806,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1841,6 +1938,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,7 +2047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2195,18 +2298,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tungstenite",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2353,22 +2456,20 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.9.2",
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 1.0.69",
- "utf-8",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2382,6 +2483,12 @@ name = "unicode-ident"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -2406,12 +2513,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -2467,6 +2568,15 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -2531,14 +2641,63 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-async"
-version = "0.1.1"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b2260b739b0e95cf9b78f22a64704af7ed9760ea12baa3745b4b97899dc89a"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-async"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f56ac33e792583916a8021e43e8a7e0987f5df7abc8f8afd72fcc361048755"
 dependencies = [
  "tokio",
  "tracing",
  "wasm-bindgen-futures",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -2563,9 +2722,9 @@ dependencies = [
 
 [[package]]
 name = "web-transport-proto"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f2dccff2e778302b6f9289cc6644e37b37629d6020a4608d4a4c2f99bd448b"
+checksum = "0225d295c8ac00a2e9a498aefeaf3f3c6186da12a251c938189b15b82ea22808"
 dependencies = [
  "bytes",
  "http",
@@ -2577,9 +2736,9 @@ dependencies = [
 
 [[package]]
 name = "web-transport-quinn"
-version = "0.11.3"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43f91486ee9d3065c017f13f4ff901928e78b2d3a124268dff821bd1caed6ca"
+checksum = "cac11b6caf163be7f980442a26fcba15e8074a5f22e85fbb71f0f77d11cecf60"
 dependencies = [
  "bytes",
  "futures",
@@ -2597,26 +2756,11 @@ dependencies = [
 
 [[package]]
 name = "web-transport-trait"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2615c30ed29953bb3727391850279a25c948c0b7a4ed2343d3a78e1d3cce2f7c"
+checksum = "fc5f83d19cf6c8ba147f4e1e5935a8a115c91f6abbf714d740a83b967d558e6e"
 dependencies = [
  "bytes",
-]
-
-[[package]]
-name = "web-transport-ws"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b1cd89c36a28eae759329839e85f7dbca733896f048a6daaf5f8fc80f3bcba"
-dependencies = [
- "bytes",
- "futures",
- "thiserror 2.0.18",
- "tokio",
- "tokio-tungstenite",
- "web-transport-proto",
- "web-transport-trait",
 ]
 
 [[package]]
@@ -2624,24 +2768,6 @@ name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.6",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2950,6 +3076,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/builds/moq-dev-rs/Cargo.toml
+++ b/builds/moq-dev-rs/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-moq-native = "0.13"
+moq-native = "0.17"
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"

--- a/builds/moq-dev-rs/config.json
+++ b/builds/moq-dev-rs/config.json
@@ -1,6 +1,6 @@
 {
   "name": "moq-dev-rs",
-  "description": "moq-dev Rust test client using moq-lite/moq-native",
+  "description": "moq-dev Rust test client using moq-net/moq-native",
   "repository": "https://github.com/moq-dev/moq",
   "targets": {
     "client": {

--- a/builds/moq-dev-rs/src/main.rs
+++ b/builds/moq-dev-rs/src/main.rs
@@ -2,12 +2,12 @@ use std::time::{Duration, Instant};
 
 use anyhow::Context;
 use clap::Parser;
-use moq_native::moq_lite;
-use moq_lite::*;
+use moq_native::moq_net;
+use moq_net::*;
 
 #[derive(Parser)]
 #[command(name = "moq-dev-rs-client")]
-#[command(about = "MoQT interop test client using moq-lite/moq-native")]
+#[command(about = "MoQT interop test client using moq-net/moq-native")]
 struct Cli {
     /// Relay URL (https:// for WebTransport, moqt:// for raw QUIC)
     #[arg(
@@ -45,11 +45,11 @@ const TESTS: &[&str] = &[
 ];
 
 /// Tests that are skipped with a reason.
-/// moq-lite doesn't support subscribing without first receiving an announcement,
-/// so tests that require eager/speculative SUBSCRIBE cannot be implemented.
+/// The moq-net consumer API doesn't support subscribing without first receiving an
+/// announcement, so tests that require eager/speculative SUBSCRIBE cannot be implemented.
 const SKIPPED_TESTS: &[(&str, &str)] = &[
-    ("subscribe-error", "moq-lite API requires announcement before subscribe"),
-    ("subscribe-before-announce", "moq-lite API requires announcement before subscribe"),
+    ("subscribe-error", "moq-net API requires announcement before subscribe"),
+    ("subscribe-before-announce", "moq-net API requires announcement before subscribe"),
 ];
 
 const TEST_NAMESPACE: &str = "moq-test/interop";
@@ -94,6 +94,25 @@ async fn main() -> anyhow::Result<()> {
     if cli.tls_disable_verify {
         client_config.tls.disable_verify = Some(true);
     }
+
+    // Optionally pin the offered protocol version(s) via MOQ_CLIENT_VERSION
+    // (comma-separated, e.g. "moq-transport-18"). By default the client offers
+    // every supported version and lets the relay choose -- which prefers the
+    // native moq-lite protocol over IETF moq-transport when both are available.
+    // Pin a version to force a specific draft for interop testing.
+    if let Ok(versions) = std::env::var("MOQ_CLIENT_VERSION") {
+        let versions = versions
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|s| s.parse::<moq_net::Version>().map_err(|e| anyhow::anyhow!(e)))
+            .collect::<anyhow::Result<Vec<_>>>()
+            .context("invalid MOQ_CLIENT_VERSION")?;
+        if !versions.is_empty() {
+            client_config.version = versions;
+        }
+    }
+
     let client = client_config.init().context("failed to init client")?;
 
     let mut all_passed = true;
@@ -198,12 +217,12 @@ async fn test_setup_only(
     client: &moq_native::Client,
     relay_url: &url::Url,
 ) -> anyhow::Result<Diagnostics> {
-    let session = client
+    let mut session = client
         .clone()
         .connect(relay_url.clone())
         .await
         .context("failed to connect")?;
-    session.close(moq_lite::Error::Cancel);
+    session.close(Error::Cancel);
 
     Ok(Diagnostics::default())
 }
@@ -213,13 +232,13 @@ async fn test_announce_only(
     client: &moq_native::Client,
     relay_url: &url::Url,
 ) -> anyhow::Result<Diagnostics> {
-    let origin = Origin::produce();
+    let origin = Origin::random().produce();
 
     // Create broadcast before connecting
-    let broadcast = Broadcast::produce();
+    let broadcast = Broadcast::new().produce();
     origin.publish_broadcast(TEST_NAMESPACE, broadcast.consume());
 
-    let session = client
+    let mut session = client
         .clone()
         .with_publish(origin.consume())
         .connect(relay_url.clone())
@@ -229,7 +248,7 @@ async fn test_announce_only(
     // Wait briefly for the announce to be processed
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    session.close(moq_lite::Error::Cancel);
+    session.close(Error::Cancel);
 
     Ok(Diagnostics::default())
 }
@@ -239,12 +258,12 @@ async fn test_publish_namespace_done(
     client: &moq_native::Client,
     relay_url: &url::Url,
 ) -> anyhow::Result<Diagnostics> {
-    let origin = Origin::produce();
+    let origin = Origin::random().produce();
 
-    let broadcast = Broadcast::produce();
+    let broadcast = Broadcast::new().produce();
     origin.publish_broadcast(TEST_NAMESPACE, broadcast.consume());
 
-    let session = client
+    let mut session = client
         .clone()
         .with_publish(origin.consume())
         .connect(relay_url.clone())
@@ -258,7 +277,7 @@ async fn test_publish_namespace_done(
     // Wait briefly for the done to propagate
     tokio::time::sleep(Duration::from_millis(200)).await;
 
-    session.close(moq_lite::Error::Cancel);
+    session.close(Error::Cancel);
 
     Ok(Diagnostics::default())
 }
@@ -269,17 +288,17 @@ async fn test_announce_subscribe(
     relay_url: &url::Url,
 ) -> anyhow::Result<Diagnostics> {
     // Publisher setup
-    let pub_origin = Origin::produce();
-    let mut broadcast = Broadcast::produce();
+    let pub_origin = Origin::random().produce();
+    let mut broadcast = Broadcast::new().produce();
     pub_origin.publish_broadcast(TEST_NAMESPACE, broadcast.consume());
 
     // Create a track so subscriber can find it
     let _track = broadcast.create_track(Track {
         name: TEST_TRACK.to_string(),
         priority: 0,
-    });
+    })?;
 
-    let pub_session = client
+    let mut pub_session = client
         .clone()
         .with_publish(pub_origin.consume())
         .connect(relay_url.clone())
@@ -290,10 +309,10 @@ async fn test_announce_subscribe(
     tokio::time::sleep(Duration::from_millis(300)).await;
 
     // Subscriber setup
-    let sub_origin = Origin::produce();
+    let sub_origin = Origin::random().produce();
     let mut sub_consumer = sub_origin.consume();
 
-    let sub_session = client
+    let mut sub_session = client
         .clone()
         .with_consume(sub_origin)
         .connect(relay_url.clone())
@@ -317,7 +336,7 @@ async fn test_announce_subscribe(
     let track = sub_broadcast.subscribe_track(&Track {
         name: TEST_TRACK.to_string(),
         priority: 0,
-    });
+    })?;
 
     // Wait for the track subscription to be acknowledged
     tokio::select! {
@@ -329,8 +348,8 @@ async fn test_announce_subscribe(
         }
     }
 
-    pub_session.close(moq_lite::Error::Cancel);
-    sub_session.close(moq_lite::Error::Cancel);
+    pub_session.close(Error::Cancel);
+    sub_session.close(Error::Cancel);
 
     Ok(Diagnostics::default())
 }

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -56,6 +56,11 @@ services:
       - TLS_DISABLE_VERIFY=1
     volumes:
       - ./mlog/client:/mlog
+      # Mount the relay's cert (read-only) so clients can pin a self-signed
+      # cert via its hash (e.g. WebTransport serverCertificateHashes) instead of
+      # relying on a relay-specific fingerprint endpoint. Ignored by clients
+      # that don't need it.
+      - ./certs:/certs:ro
     # Resource limits
     deploy:
       resources:

--- a/generate-certs.sh
+++ b/generate-certs.sh
@@ -18,11 +18,15 @@ CERTS_DIR="${1:-./certs}"
 
 mkdir -p "$CERTS_DIR"
 
-# Generate self-signed cert valid for localhost, relay hostname, and common test hostnames
-openssl req -x509 -newkey rsa:4096 \
+# Generate self-signed cert valid for localhost, relay hostname, and common test hostnames.
+#
+# ECDSA P-256 with a short (10-day) validity so the cert satisfies the WebTransport
+# `serverCertificateHashes` policy (ECDSA key + <=14-day validity), letting browser
+# and node/bun clients pin it by hash without a trusted CA.
+openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
     -keyout "$CERTS_DIR/priv.key" \
     -out "$CERTS_DIR/cert.pem" \
-    -days 365 -nodes \
+    -days 10 -nodes \
     -subj "/CN=localhost" \
     -addext "subjectAltName=DNS:localhost,DNS:relay,DNS:moq-relay,IP:127.0.0.1"
 

--- a/implementations.json
+++ b/implementations.json
@@ -92,9 +92,10 @@
         "draft-14",
         "draft-15",
         "draft-16",
-        "draft-17"
+        "draft-17",
+        "draft-18"
       ],
-      "notes": "Bun/TypeScript test client using @moq/lite npm package with @moq/web-transport polyfill. Supports multiple draft versions via version negotiation.",
+      "notes": "Bun/TypeScript test client using @moq/net npm package with @moq/web-transport polyfill. Supports all moq-transport draft versions 14+ via version negotiation.",
       "roles": {
         "client": {
           "docker": {
@@ -112,9 +113,10 @@
         "draft-14",
         "draft-15",
         "draft-16",
-        "draft-17"
+        "draft-17",
+        "draft-18"
       ],
-      "notes": "Rust implementation by kixelated, supports moq-lite and IETF MoQT. Supports multiple draft versions via version negotiation.",
+      "notes": "Rust implementation by kixelated, supports moq-lite and IETF MoQT. Test client built on moq-net/moq-native. Supports all moq-transport draft versions 14+ via version negotiation.",
       "roles": {
         "relay": {
           "docker": {
@@ -123,7 +125,7 @@
               "dockerfile": "adapters/moq-dev-rs/Dockerfile.relay",
               "context": "adapters/moq-dev-rs"
             },
-            "upstream_image": "docker.io/kixelated/moq-relay",
+            "upstream_image": "docker.io/moqdev/moq-relay",
             "notes": "Adapter wraps upstream image with /certs convention"
           },
           "remote": [

--- a/implementations.json
+++ b/implementations.json
@@ -106,8 +106,8 @@
       "name": "moq (moq-dev)",
       "organization": "Luke Curley",
       "repository": "https://github.com/moq-dev/moq",
-      "draft_versions": ["draft-14", "draft-16"],
-      "notes": "Rust implementation by kixelated, supports moq-lite and IETF MoQT. Supports multiple draft versions via version negotiation.",
+      "draft_versions": ["draft-14", "draft-15", "draft-16", "draft-17", "draft-18"],
+      "notes": "Rust implementation by kixelated, supports moq-lite and IETF MoQT. Test client built on moq-net/moq-native. Supports all moq-transport draft versions 14+ via version negotiation.",
       "roles": {
         "relay": {
           "docker": {
@@ -116,7 +116,7 @@
               "dockerfile": "adapters/moq-dev-rs/Dockerfile.relay",
               "context": "adapters/moq-dev-rs"
             },
-            "upstream_image": "docker.io/kixelated/moq-relay",
+            "upstream_image": "docker.io/moqdev/moq-relay",
             "notes": "Adapter wraps upstream image with /certs convention"
           },
           "remote": [
@@ -140,8 +140,8 @@
       "name": "moq (moq-dev, JS)",
       "organization": "Luke Curley",
       "repository": "https://github.com/moq-dev/moq",
-      "draft_versions": ["draft-14", "draft-16"],
-      "notes": "Bun/TypeScript test client using @moq/lite npm package. Supports multiple draft versions via version negotiation.",
+      "draft_versions": ["draft-14", "draft-15", "draft-16", "draft-17", "draft-18"],
+      "notes": "Bun/TypeScript test client using @moq/net npm package. Supports all moq-transport draft versions 14+ via version negotiation.",
       "roles": {
         "client": {
           "docker": {


### PR DESCRIPTION
## What

Brings both moq-dev test clients up to the current moq-dev API and makes them runnable in the local Docker/Podman interop matrix.

### moq-dev-rs
- Bump `moq-native` 0.13 → **0.17**. The `moq_lite` module is gone; migrated to the `moq_net` core API (`Origin::random().produce()`, `Broadcast::new()`, `Result`-returning `create_track`/`subscribe_track`, `&mut Session::close`, `moq_net::Error`).
- Pin `web-transport-quinn` 0.11.9 in `Cargo.lock` — the freshly-resolved 0.11.3 fails to compile against `moq-native` 0.17 (`.conn()` → `.connect()` rename).
- Honor `MOQ_CLIENT_VERSION` (e.g. `moq-transport-18`) to pin the offered protocol version. By default moq-dev↔moq-dev negotiates **moq-lite**, so pinning is required to exercise a specific IETF draft.

### moq-dev-js
- Migrate `@moq/lite` 0.1.3 → `@moq/net` 0.1.2 (`@moq/lite` is deprecated, renamed to `@moq/net`).
- Replace the `@fails-components` WebTransport polyfill with moq-dev's own **`@moq/web-transport`**, which connects reliably under bun/node.
- For self-signed certs, pin the mounted cert via WebTransport `serverCertificateHashes` (SHA-256 of the leaf DER) over `https://`, instead of the `http://` `/certificate.sha256` fingerprint fetch (a moq.dev-only, non-standard convention). Falls back to the fetch when no cert is mounted (remote moq.dev).
- `tsconfig`: explicit `types` + `allowImportingTsExtensions` (the polyfill ships raw `.ts`); add `@types/node`.

### Test harness
- `generate-certs.sh`: **ECDSA P-256, 10-day** validity (was RSA-4096/365d), so the cert satisfies the WebTransport `serverCertificateHashes` policy (ECDSA + ≤14 days).
- `docker-compose.test.yml`: mount `./certs:/certs:ro` into the test client so it can pin the relay cert by hash. Ignored by clients that don't need it.

### Registry
- `moq-dev-rs`/`moq-dev-js` `draft_versions` → **draft-14…18** (all moq-transport 14+).
- Relay image rename: `docker.io/kixelated/moq-relay` → **`moqdev/moq-relay`** (adapter Dockerfile + `upstream_image`).

## Why

`moq-dev` moved on (crate/package renames, polyfill change, image rename) and the in-tree clients no longer built or connected. This re-aligns them and makes local interop runnable again.

## Results (local, Podman)

Both clients pass 6/6 against the moq-dev, moq-rs, and moxygen relays (default negotiation), with one known **relay-side** gap:

| client → relay | moq-dev | moq-rs | moxygen |
|---|---|---|---|
| moq-dev-rs | ✅ 6/6 | ⚠️ 5/6 | ✅ 6/6 |
| moq-dev-js | ✅ 6/6 | ✅ 6/6 | ✅ 6/6 |

- `moq-dev-rs` `announce-subscribe` → `moq-rs` times out because the moq-rs relay does not implement `SUBSCRIBE_NAMESPACE` (announce discovery). Not a client bug — passes against relays that do.
- `moq-dev-rs` pinned to `moq-transport-18` negotiates draft-18 and passes against a relay built from current moq source. The **published `moqdev/moq-relay` image** still fails draft-18 `announce-subscribe` (fixed in source, stale in the image) — worth republishing.

## Reviewer notes
- The published `moqdev/moq-relay` image is arm64-native and healthy; an earlier `kixelated/moq-relay` reference crashed on jemalloc-profiling activation (stale image) — the rename to `moqdev/moq-relay` resolves it.
- `_ensure-certs` only checks cert *existence*, not expiry; with the new 10-day window a long-lived `./certs` could expire between runs. Left as-is for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)