### PR TITLE
Add aiomoqt relay (experimental, draft-16 WebTransport)

### DIFF
--- a/adapters/aiomoqt/Dockerfile.relay
+++ b/adapters/aiomoqt/Dockerfile.relay
@@ -1,0 +1,32 @@
+# aiomoqt adapter for MoQT interop testing (relay role)
+#
+# EXPERIMENTAL control-plane-only interop relay: no data forwarding, no
+# auth, no scale handling. It exists to exercise the 6 standard interop
+# cases (SETUP / PUBLISH_NAMESPACE / SUBSCRIBE + errors). Use moxygen or
+# moq-rs for real workloads.
+#
+# Wraps the prebuilt aiomoqt image (which carries the MOQT_ROLE switch)
+# and pins relay mode + draft-16 WebTransport on the /certs convention
+# (cert.pem / priv.key). Serves on UDP/4443.
+#
+# Build:
+#   docker build -t aiomoqt-interop-relay:latest \
+#     -f adapters/aiomoqt/Dockerfile.relay adapters/aiomoqt/
+#
+# Usage:
+#   docker run -v ./certs:/certs -p 4443:4443/udp aiomoqt-interop-relay:latest
+FROM ghcr.io/gmarzot/aiomoqt:latest
+
+# The image's entrypoint reads these (docker-entrypoint.sh): relay role,
+# draft-16, WebTransport (no MOQT_QUIC). Certs default to
+# /certs/cert.pem + /certs/priv.key.
+ENV MOQT_ROLE=relay
+ENV MOQT_PORT=4443
+ENV MOQT_DRAFT=16
+
+EXPOSE 4443/udp
+
+# The python:slim base lacks ss/netstat; check /proc/net/udp(6) for port
+# 4443 (0x115B). Mirrors the moxygen / moq-dev-rs adapters.
+HEALTHCHECK --interval=2s --timeout=5s --start-period=5s --retries=10 \
+    CMD grep -qi ":115B" /proc/net/udp6 || grep -qi ":115B" /proc/net/udp || exit 1

--- a/adapters/aiomoqt/Dockerfile.relay
+++ b/adapters/aiomoqt/Dockerfile.relay
@@ -1,13 +1,11 @@
 # aiomoqt adapter for MoQT interop testing (relay role)
 #
-# EXPERIMENTAL control-plane-only interop relay: no data forwarding, no
-# auth, no scale handling. It exists to exercise the 6 standard interop
-# cases (SETUP / PUBLISH_NAMESPACE / SUBSCRIBE + errors). Use moxygen or
-# moq-rs for real workloads.
+# aiomoqt server-side control plane over WebTransport (draft-16):
+# SETUP, PUBLISH_NAMESPACE, SUBSCRIBE. No object forwarding.
 #
-# Wraps the prebuilt aiomoqt image (which carries the MOQT_ROLE switch)
-# and pins relay mode + draft-16 WebTransport on the /certs convention
-# (cert.pem / priv.key). Serves on UDP/4443.
+# Wraps the prebuilt aiomoqt image (MOQT_ROLE switch), pinning relay
+# mode + draft-16 WebTransport on the /certs convention (cert.pem /
+# priv.key). Serves on UDP/4443.
 #
 # Build:
 #   docker build -t aiomoqt-interop-relay:latest \
@@ -27,6 +25,6 @@ ENV MOQT_DRAFT=16
 EXPOSE 4443/udp
 
 # The python:slim base lacks ss/netstat; check /proc/net/udp(6) for port
-# 4443 (0x115B). Mirrors the moxygen / moq-dev-rs adapters.
+# 4443 (0x115B).
 HEALTHCHECK --interval=2s --timeout=5s --start-period=5s --retries=10 \
     CMD grep -qi ":115B" /proc/net/udp6 || grep -qi ":115B" /proc/net/udp || exit 1

--- a/implementations.json
+++ b/implementations.json
@@ -22,6 +22,28 @@
         }
       }
     },
+    "aiomoqt-relay": {
+      "name": "aiomoqt (relay)",
+      "organization": "MarzResearch",
+      "repository": "https://github.com/gmarzot/aiomoqt",
+      "draft_versions": [
+        "draft-16"
+      ],
+      "notes": "EXPERIMENTAL control-plane-only interop relay for aiomoqt (Python asyncio MoQT). No data forwarding, no auth, no scale handling — exercises the 6 standard interop cases over WebTransport at draft-16. Use moxygen / moq-rs for real workloads. Pinned to draft-16; full multi-version relay negotiation is planned for a future release.",
+      "roles": {
+        "relay": {
+          "docker": {
+            "image": "aiomoqt-interop-relay:latest",
+            "build": {
+              "dockerfile": "adapters/aiomoqt/Dockerfile.relay",
+              "context": "adapters/aiomoqt"
+            },
+            "upstream_image": "ghcr.io/gmarzot/aiomoqt:latest",
+            "notes": "Adapter pins relay mode + draft-16 WebTransport on the /certs convention (MOQT_ROLE=relay)."
+          }
+        }
+      }
+    },
     "imquic": {
       "name": "imquic",
       "organization": "Meetecho",

--- a/implementations.json
+++ b/implementations.json
@@ -29,7 +29,7 @@
       "draft_versions": [
         "draft-16"
       ],
-      "notes": "EXPERIMENTAL control-plane-only interop relay for aiomoqt (Python asyncio MoQT). No data forwarding, no auth, no scale handling — exercises the 6 standard interop cases over WebTransport at draft-16. Use moxygen / moq-rs for real workloads. Pinned to draft-16; full multi-version relay negotiation is planned for a future release.",
+      "notes": "aiomoqt server-side control plane over WebTransport (draft-16): SETUP, PUBLISH_NAMESPACE, SUBSCRIBE. No object forwarding.",
       "roles": {
         "relay": {
           "docker": {


### PR DESCRIPTION
## Summary

Adds aiomoqt's control-plane-only interop **relay** as a new `aiomoqt-relay` implementation so clients can be tested against it. The existing `aiomoqt` client entry is unchanged.

- **`adapters/aiomoqt/Dockerfile.relay`** — wraps the prebuilt `ghcr.io/gmarzot/aiomoqt:latest` image in relay mode (`MOQT_ROLE=relay`, draft-16, WebTransport on the `/certs` convention), with a `/proc/net/udp` healthcheck (the python-slim base lacks `ss`/`netstat`). Mirrors the moxygen / moq-dev-rs adapters.
- **`implementations.json`** — new `aiomoqt-relay` entry: `draft_versions: ["draft-16"]`, `roles.relay` (docker build).

## Why a separate `aiomoqt-relay` entry, draft-16 only?

The relay serves **one draft per instance** today — the negotiated version is process-global, so a single relay can't hold both drafts at once (per-session multi-version negotiation is planned in a future aiomoqt release). Since `draft_versions` is impl-level, a separate draft-16-scoped entry lets the runner pair it only with draft-16 clients, avoiding spurious failures for draft-14-only clients.

## Caveats

**EXPERIMENTAL / control-plane-only** — no data forwarding, no auth, no scale handling. It exists to exercise the 6 standard interop cases (SETUP / PUBLISH_NAMESPACE / SUBSCRIBE + errors). Use moxygen / moq-rs for real workloads.

## Validation

Built the adapter image and ran it exactly as the runner does (mount `/certs`, `MOQT_ROLE=relay` env); a client scores **6/6** against the dockerized relay over WebTransport — all six standard cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
