### PR TITLE
Fix zombie-state race in run_with_timeout watchdog fallback

### DIFF
--- a/builds/moqtopus/Dockerfile.client
+++ b/builds/moqtopus/Dockerfile.client
@@ -1,0 +1,53 @@
+# syntax=docker/dockerfile:1
+
+FROM ubuntu:24.04 AS builder
+
+ARG VCPKG_REF=7fb558b02523aaa5f1f297e12d695962ce15fc92
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential ca-certificates cmake curl git ninja-build pkg-config \
+        tar unzip zip && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git init /opt/vcpkg && \
+    git -C /opt/vcpkg remote add origin https://github.com/microsoft/vcpkg.git && \
+    git -C /opt/vcpkg fetch --depth 1 origin "${VCPKG_REF}" && \
+    git -C /opt/vcpkg checkout --detach FETCH_HEAD && \
+    /opt/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+
+WORKDIR /build
+COPY . .
+
+ENV VCPKG_ROOT=/opt/vcpkg
+RUN sed -i \
+        -e 's/"kind": "git"/"kind": "builtin"/' \
+        -e '/"baseline":/s/,$//' \
+        -e '\|"repository": "https://github.com/microsoft/vcpkg"$|d' \
+        vcpkg-configuration.json && \
+    cmake --preset=vcpkg -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build build --target moqtopus_interop_client && \
+    mkdir -p /runtime-libs && \
+    cp -a build/vcpkg_installed/*-linux/lib/libmsquic.so* /runtime-libs/
+
+FROM ubuntu:24.04 AS runtime
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates libatomic1 libnuma1 && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=builder /build/build/moqtopus_interop_client /app/moqtopus-interop-client
+COPY --from=builder /runtime-libs/ /usr/local/lib/
+COPY moqtopus-interop-entrypoint.sh /app/entrypoint.sh
+
+RUN chmod +x /app/entrypoint.sh && \
+    mkdir -p /mlog && \
+    chmod 0777 /mlog && \
+    ldconfig
+
+ENV RELAY_URL=moqt://relay:4443
+ENV TLS_DISABLE_VERIFY=0
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/builds/moqtopus/build.sh
+++ b/builds/moqtopus/build.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+set -euo pipefail
+
+IMPL_NAME="moqtopus"
+REPO_URL="https://github.com/kota-yata/Moqtopus.git"
+DEFAULT_REF="main"
+
+BUILD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCES_DIR="${BUILD_DIR}/.sources"
+RUNNER_ROOT="$(cd "${BUILD_DIR}/../.." && pwd)"
+
+log() {
+    echo "[build] $*" >&2
+}
+
+error() {
+    echo "[build] ERROR: $*" >&2
+    exit 1
+}
+
+get_git_commit() {
+    git -C "$1" rev-parse HEAD 2>/dev/null || echo "unknown"
+}
+
+is_git_dirty() {
+    if git -C "$1" diff --quiet HEAD 2>/dev/null && \
+       git -C "$1" diff --cached --quiet HEAD 2>/dev/null; then
+        echo "false"
+    else
+        echo "true"
+    fi
+}
+
+REF=""
+LOCAL_PATH=""
+TARGET=""
+CUSTOM_REPO=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --ref)
+            [[ -n "${2:-}" ]] || error "--ref requires a value"
+            REF="$2"
+            shift 2
+            ;;
+        --repo)
+            [[ -n "${2:-}" ]] || error "--repo requires a value"
+            CUSTOM_REPO="$2"
+            shift 2
+            ;;
+        --local)
+            [[ -n "${2:-}" ]] || error "--local requires a value"
+            LOCAL_PATH="$2"
+            shift 2
+            ;;
+        --target)
+            [[ -n "${2:-}" ]] || error "--target requires a value"
+            TARGET="$2"
+            shift 2
+            ;;
+        --help|-h)
+            echo "Usage: $0 [--ref REF | --local PATH] [--repo URL] [--target client]"
+            exit 0
+            ;;
+        *)
+            error "Unknown option: $1"
+            ;;
+    esac
+done
+
+[[ -z "$CUSTOM_REPO" ]] || REPO_URL="$CUSTOM_REPO"
+[[ -z "$REF" || -z "$LOCAL_PATH" ]] || error "Cannot specify both --ref and --local"
+[[ -z "$CUSTOM_REPO" || -z "$LOCAL_PATH" ]] || error "Cannot specify both --repo and --local"
+[[ -z "$TARGET" || "$TARGET" = "client" ]] || error "Only the client target is supported"
+
+if [[ -n "$LOCAL_PATH" ]]; then
+    [[ -d "$LOCAL_PATH" ]] || error "Local path does not exist: $LOCAL_PATH"
+    SOURCE_DIR="$(cd "$LOCAL_PATH" && pwd)"
+    SOURCE_TYPE="local"
+    log "Using local checkout: $SOURCE_DIR"
+else
+    REF="${REF:-$DEFAULT_REF}"
+    SOURCE_DIR="${SOURCES_DIR}/${IMPL_NAME}"
+    SOURCE_TYPE="git"
+    mkdir -p "$SOURCES_DIR"
+
+    if [[ -d "$SOURCE_DIR/.git" ]]; then
+        EXISTING_URL=$(git -C "$SOURCE_DIR" remote get-url origin 2>/dev/null || echo "")
+        if [[ "$EXISTING_URL" != "$REPO_URL" ]]; then
+            rm -rf "$SOURCE_DIR"
+            git clone "$REPO_URL" "$SOURCE_DIR"
+        else
+            git -C "$SOURCE_DIR" fetch origin
+        fi
+    else
+        rm -rf "$SOURCE_DIR"
+        git clone "$REPO_URL" "$SOURCE_DIR"
+    fi
+
+    git -C "$SOURCE_DIR" checkout "$REF"
+    git -C "$SOURCE_DIR" pull origin "$REF" 2>/dev/null || true
+fi
+
+SOURCE_COMMIT=$(get_git_commit "$SOURCE_DIR")
+SOURCE_DIRTY=$(is_git_dirty "$SOURCE_DIR")
+ENTRYPOINT_DEST="${SOURCE_DIR}/moqtopus-interop-entrypoint.sh"
+
+cleanup() {
+    rm -f "$ENTRYPOINT_DEST"
+}
+trap cleanup EXIT
+
+cp "${BUILD_DIR}/entrypoint-client.sh" "$ENTRYPOINT_DEST"
+
+log "Building client -> moqtopus-interop-client:latest"
+docker build \
+    -f "${BUILD_DIR}/Dockerfile.client" \
+    -t moqtopus-interop-client:latest \
+    "$SOURCE_DIR"
+
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+RUNNER_COMMIT=$(git -C "$RUNNER_ROOT" rev-parse HEAD 2>/dev/null || echo "unknown")
+
+jq -n \
+    --arg impl "$IMPL_NAME" \
+    --arg ts "$TIMESTAMP" \
+    --arg runner_commit "$RUNNER_COMMIT" \
+    --arg source_type "$SOURCE_TYPE" \
+    --arg repo "$REPO_URL" \
+    --arg ref "${REF:-local}" \
+    --arg local_path "${LOCAL_PATH:-}" \
+    --arg commit "$SOURCE_COMMIT" \
+    --argjson dirty "$SOURCE_DIRTY" \
+    '{
+        implementation: $impl,
+        timestamp: $ts,
+        runner_commit: $runner_commit,
+        source: {
+            type: $source_type,
+            repository: $repo,
+            ref: $ref,
+            local_path: (if $local_path == "" then null else $local_path end),
+            commit: $commit,
+            dirty: $dirty
+        },
+        images: [
+            {target: "client", image: "moqtopus-interop-client:latest"}
+        ]
+    }' | tee "${BUILD_DIR}/.last-build.json"

--- a/builds/moqtopus/config.json
+++ b/builds/moqtopus/config.json
@@ -1,0 +1,13 @@
+{
+  "name": "moqtopus",
+  "description": "C++ MoQT subscriber implementation using MsQuic",
+  "repository": "https://github.com/kota-yata/Moqtopus.git",
+  "default_ref": "main",
+  "targets": {
+    "client": {
+      "dockerfile": "Dockerfile.client",
+      "image_name": "moqtopus-interop-client",
+      "context": ".sources/moqtopus"
+    }
+  }
+}

--- a/builds/moqtopus/entrypoint-client.sh
+++ b/builds/moqtopus/entrypoint-client.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ARGS=()
+
+if [ -n "${RELAY_URL:-}" ]; then
+    ARGS+=(--relay "$RELAY_URL")
+fi
+
+if [ -n "${TESTCASE:-}" ]; then
+    ARGS+=(--test "$TESTCASE")
+fi
+
+if [ "${TLS_DISABLE_VERIFY:-}" = "1" ] || [ "${TLS_DISABLE_VERIFY:-}" = "true" ]; then
+    ARGS+=(--tls-disable-verify)
+fi
+
+if [ "${VERBOSE:-}" = "1" ] || [ "${VERBOSE:-}" = "true" ]; then
+    ARGS+=(--verbose)
+fi
+
+exec /app/moqtopus-interop-client "${ARGS[@]}"

--- a/run-interop-tests.sh
+++ b/run-interop-tests.sh
@@ -220,6 +220,56 @@ classify_version() {
     fi
 }
 
+# Run a command with a wall-clock timeout.
+#
+# GNU coreutils installs this as `timeout` on Linux and commonly as
+# `gtimeout` on macOS. The watchdog fallback keeps the runner usable with the
+# default macOS toolchain and Bash 3.2.
+run_with_timeout() {
+    local seconds="$1"
+    shift
+
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "$seconds" "$@"
+        return $?
+    fi
+    if command -v gtimeout >/dev/null 2>&1; then
+        gtimeout "$seconds" "$@"
+        return $?
+    fi
+
+    local timeout_marker
+    timeout_marker=$(mktemp "${TMPDIR:-/tmp}/moq-interop-timeout.XXXXXX")
+    rm -f "$timeout_marker"
+
+    "$@" &
+    local command_pid=$!
+
+    (
+        sleep "$seconds"
+        if kill -0 "$command_pid" 2>/dev/null; then
+            : > "$timeout_marker"
+            kill -TERM "$command_pid" 2>/dev/null || true
+            sleep 2
+            kill -KILL "$command_pid" 2>/dev/null || true
+        fi
+    ) &
+    local watchdog_pid=$!
+
+    local command_status=0
+    wait "$command_pid" || command_status=$?
+    kill "$watchdog_pid" 2>/dev/null || true
+    wait "$watchdog_pid" 2>/dev/null || true
+
+    if [ -f "$timeout_marker" ]; then
+        rm -f "$timeout_marker"
+        return 124
+    fi
+
+    rm -f "$timeout_marker"
+    return "$command_status"
+}
+
 # Check if a Docker image exists locally.
 # Returns 0 if the image is available, 1 otherwise.
 image_exists() {
@@ -382,7 +432,7 @@ run_test() {
     fi
 
     if [[ "$mode" == "docker" ]]; then
-        if timeout "$test_timeout" make test RELAY_IMAGE="$target" CLIENT_IMAGE="$client_image" > "$result_file" 2>&1; then
+        if run_with_timeout "$test_timeout" make test RELAY_IMAGE="$target" CLIENT_IMAGE="$client_image" > "$result_file" 2>&1; then
             status="pass"
             PASSED=$((PASSED + 1))
             echo -e "${GREEN}✓ PASSED${NC}"
@@ -403,7 +453,7 @@ run_test() {
         local -a make_args=("test-external" "RELAY_URL=$target" "CLIENT_IMAGE=$client_image")
         [ "$tls_disable" = "true" ] && make_args+=("TLS_DISABLE_VERIFY=1")
 
-        if timeout "$test_timeout" make "${make_args[@]}" > "$result_file" 2>&1; then
+        if run_with_timeout "$test_timeout" make "${make_args[@]}" > "$result_file" 2>&1; then
             status="pass"
             PASSED=$((PASSED + 1))
             echo -e "${GREEN}✓ PASSED${NC}"

--- a/run-interop-tests.sh
+++ b/run-interop-tests.sh
@@ -258,9 +258,17 @@ run_with_timeout() {
 
     local command_status=0
     wait "$command_pid" || command_status=$?
-    kill "$watchdog_pid" 2>/dev/null || true
+
+    # Check if watchdog is still alive — if yes, command finished before timeout
+    if kill -0 "$watchdog_pid" 2>/dev/null; then
+        kill "$watchdog_pid" 2>/dev/null || true
+        wait "$watchdog_pid" 2>/dev/null || true
+        rm -f "$timeout_marker"
+        return "$command_status"
+    fi
     wait "$watchdog_pid" 2>/dev/null || true
 
+    # Watchdog already exited — it fired the timeout
     if [ -f "$timeout_marker" ]; then
         rm -f "$timeout_marker"
         return 124


### PR DESCRIPTION
Fixes a race condition in the `run_with_timeout` bash fallback added in #84.

`kill -0 $pid` returns success for zombie processes — if a command finishes at the same moment the watchdog's `sleep` expires, the watchdog writes the timeout marker and the caller returns 124 (TIMEOUT) for a run that actually passed.

Fix by checking whether the watchdog is still alive after `wait` returns instead. If the watchdog is still alive, the command finished before the timeout fired — kill the watchdog and return the real exit status. Only if the watchdog is already dead did it fire the timeout.