### PR TITLE
aiomoqt: advertise draft-18 (client self-selects per relay via preference-ordered SETUP probe)

### DIFF
--- a/adapters/aiomoqt/Dockerfile.relay
+++ b/adapters/aiomoqt/Dockerfile.relay
@@ -1,10 +1,10 @@
 # aiomoqt adapter for MoQT interop testing (relay role)
 #
-# aiomoqt server-side control plane over WebTransport (draft-16):
+# aiomoqt server-side control plane over WebTransport (draft-16/18):
 # SETUP, PUBLISH_NAMESPACE, SUBSCRIBE. No object forwarding.
 #
 # Wraps the prebuilt aiomoqt image (MOQT_ROLE switch), pinning relay
-# mode + draft-16 WebTransport on the /certs convention (cert.pem /
+# mode + draft-16/18 WebTransport on the /certs convention (cert.pem /
 # priv.key). Serves on UDP/4443.
 #
 # Build:
@@ -16,11 +16,12 @@
 FROM ghcr.io/gmarzot/aiomoqt:latest
 
 # The image's entrypoint reads these (docker-entrypoint.sh): relay role,
-# draft-16, WebTransport (no MOQT_QUIC). Certs default to
-# /certs/cert.pem + /certs/priv.key.
+# draft-16 + draft-18 (advertises both WT-protocols, server negotiates),
+# WebTransport (no MOQT_QUIC). Certs default to /certs/cert.pem +
+# /certs/priv.key.
 ENV MOQT_ROLE=relay
 ENV MOQT_PORT=4443
-ENV MOQT_DRAFT=16
+ENV MOQT_DRAFT=16,18
 
 EXPOSE 4443/udp
 

--- a/adapters/aiomoqt/Dockerfile.relay.quic
+++ b/adapters/aiomoqt/Dockerfile.relay.quic
@@ -1,0 +1,29 @@
+# aiomoqt adapter for MoQT interop testing (relay role, raw QUIC)
+#
+# Same control-plane relay as Dockerfile.relay, but served over raw QUIC
+# (moqt://) instead of WebTransport. aiopquic can't dual-ALPN one UDP
+# port, so QUIC and WT are separate single-transport instances; this one
+# sets MOQT_QUIC=1 so the entrypoint passes --quic (raw QUIC on the
+# primary port). draft-16 + draft-18. No object forwarding.
+#
+# Build:
+#   docker build -t aiomoqt-interop-relay-quic:latest \
+#     -f adapters/aiomoqt/Dockerfile.relay.quic adapters/aiomoqt/
+#
+# Usage:
+#   docker run -v ./certs:/certs -p 4443:4443/udp aiomoqt-interop-relay-quic:latest
+FROM ghcr.io/gmarzot/aiomoqt:latest
+
+# Entrypoint (docker-entrypoint.sh): relay role, raw QUIC (MOQT_QUIC set
+# → --quic), draft-16/18. Certs default to /certs/cert.pem + /certs/priv.key.
+ENV MOQT_ROLE=relay
+ENV MOQT_PORT=4443
+ENV MOQT_DRAFT=16,18
+ENV MOQT_QUIC=1
+
+EXPOSE 4443/udp
+
+# The python:slim base lacks ss/netstat; check /proc/net/udp(6) for port
+# 4443 (0x115B).
+HEALTHCHECK --interval=2s --timeout=5s --start-period=5s --retries=10 \
+    CMD grep -qi ":115B" /proc/net/udp6 || grep -qi ":115B" /proc/net/udp || exit 1

--- a/implementations.json
+++ b/implementations.json
@@ -28,19 +28,45 @@
       "organization": "MarzResearch",
       "repository": "https://github.com/gmarzot/aiomoqt",
       "draft_versions": [
-        "draft-16"
+        "draft-16",
+        "draft-18"
       ],
-      "notes": "aiomoqt server-side control plane over WebTransport (draft-16): SETUP, PUBLISH_NAMESPACE, SUBSCRIBE. No object forwarding.",
+      "notes": "aiomoqt server-side control plane over WebTransport (draft-16/18): SETUP, PUBLISH_NAMESPACE, SUBSCRIBE. No object forwarding.",
       "roles": {
         "relay": {
           "docker": {
             "image": "aiomoqt-interop-relay:latest",
+            "url": "https://relay:4443",
             "build": {
               "dockerfile": "adapters/aiomoqt/Dockerfile.relay",
               "context": "adapters/aiomoqt"
             },
             "upstream_image": "ghcr.io/gmarzot/aiomoqt:latest",
-            "notes": "Adapter pins relay mode + draft-16 WebTransport on the /certs convention (MOQT_ROLE=relay)."
+            "notes": "Adapter pins relay mode + draft-16/18 WebTransport on the /certs convention (MOQT_ROLE=relay)."
+          }
+        }
+      }
+    },
+    "aiomoqt-relay-quic": {
+      "name": "aiomoqt (relay, raw QUIC)",
+      "organization": "MarzResearch",
+      "repository": "https://github.com/gmarzot/aiomoqt",
+      "draft_versions": [
+        "draft-16",
+        "draft-18"
+      ],
+      "notes": "Same aiomoqt control-plane relay over raw QUIC (moqt://) instead of WebTransport. aiopquic can't dual-ALPN one UDP port, so QUIC is a separate single-transport instance (MOQT_QUIC=1). No object forwarding.",
+      "roles": {
+        "relay": {
+          "docker": {
+            "image": "aiomoqt-interop-relay-quic:latest",
+            "url": "moqt://relay:4443",
+            "build": {
+              "dockerfile": "adapters/aiomoqt/Dockerfile.relay.quic",
+              "context": "adapters/aiomoqt"
+            },
+            "upstream_image": "ghcr.io/gmarzot/aiomoqt:latest",
+            "notes": "Adapter pins relay mode + raw QUIC (MOQT_QUIC=1) + draft-16/18 on the /certs convention."
           }
         }
       }

--- a/implementations.json
+++ b/implementations.json
@@ -10,9 +10,10 @@
       "repository": "https://github.com/gmarzot/aiomoqt",
       "draft_versions": [
         "draft-14",
-        "draft-16"
+        "draft-16",
+        "draft-18"
       ],
-      "notes": "Python asyncio implementation of MoQT. Supports draft-14 and draft-16 via version negotiation.",
+      "notes": "Python asyncio implementation of MoQT. Supports draft-14, draft-16, and draft-18. The client self-selects the wire version per relay via a preference-ordered SETUP probe (16 -> 14 -> 18), pinning the first that completes, so a single image prefers draft-16 against draft-16-capable relays while still reaching draft-18-only relays.",
       "roles": {
         "client": {
           "docker": {


### PR DESCRIPTION
The aiomoqt client now speaks **draft-18** (over both raw QUIC and WebTransport) alongside draft-14/16, so this advertises `draft-18` in its `draft_versions`. That stops the runner from skipping draft-18-only relays for the aiomoqt client row, while leaving its draft-14/16 behavior unchanged.

### Version selection (no per-column config needed)
The runner doesn't pass a negotiated draft to clients, so the aiomoqt client self-selects the wire version per relay: it probes its supported drafts in **preference order** with a single-ALPN SETUP each (**16 → 14 → 18**) and pins the first that completes. So one image:

- **prefers draft-16** against draft-16-capable relays (no draft-16 → draft-18 regression on dual-version relays),
- **still reaches draft-18-only** relays,
- stays **deterministic** — single-ALPN per probe, no multi-offer server-choice ambiguity.

This ships in `ghcr.io/gmarzot/aiomoqt:latest` (aiomoqt 0.10.1+).

Related to #85 (multi-version support): the self-select probe is the client-side accommodation for the current "one declared version per (client, relay) pair" model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)