### PR TITLE
Add moq-go (draft-18) relay + client integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ SHELL := /bin/bash
 .PHONY: test test-verbose test-single test-external clean mlog-clean certs \
         interop-all interop-docker interop-remote interop-relay interop-client interop-list \
         relay-start relay-stop logs logs-relay logs-client \
-        build-adapters build-moxygen-adapter build-impl build-moq-rs report help _ensure-certs
+        build-adapters build-moxygen-adapter build-impl build-moq-rs build-moq-go report help _ensure-certs
 
 #############################################################################
 # Image Configuration
@@ -228,6 +228,10 @@ build-impl:
 build-moq-rs:
 	@./builds/moq-rs/build.sh $(BUILD_ARGS)
 
+# Convenience target for moq-go
+build-moq-go:
+	@./builds/moq-go/build.sh $(BUILD_ARGS)
+
 #############################################################################
 # Report Generation
 #############################################################################
@@ -267,6 +271,7 @@ help:
 	@echo "  build-adapters        Build all adapter images"
 	@echo "  build-impl            Build from source: make build-impl IMPL=moq-rs"
 	@echo "  build-moq-rs          Convenience target for moq-rs"
+	@echo "  build-moq-go          Convenience target for moq-go"
 	@echo ""
 	@echo "  BUILD_ARGS examples:"
 	@echo "    --local ~/git/moq-rs    Use local checkout"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Filter a single relay: `make interop-remote RELAY=moxygen`. See [Getting Started
 | MOQtail | OzU | 16 | relay | `https://relay.moqtail.dev` |
 | libquicr | Cisco | 14 | relay | `https://us-west-2.relay.quicr.org:33437/relay` |
 | imquic | Meetecho | 16-18 | relay, client | `https://lminiero.it:9000` |
+| moq-go | floatdrop | 18 | relay, client | (build from source) |
 
 This table is a snapshot — run `make interop-list` or see [`implementations.json`](./implementations.json) for the current state. See [IMPLEMENTATIONS.md](./IMPLEMENTATIONS.md) for how to add your implementation.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Filter a single relay: `make interop-remote RELAY=moxygen`. See [Getting Started
 | MOQtail | OzU | 16 | relay | `https://relay.moqtail.dev` |
 | libquicr | Cisco | 14 | relay | `https://us-west-2.relay.quicr.org:33437/relay` |
 | imquic | Meetecho | 16-18 | relay, client | `https://lminiero.it:9000` |
-| moq-go | floatdrop | 18 | relay, client | (build from source) |
+| moq-go | Vsevolod Strukchinsky | 18 | relay, client |  |
 
 This table is a snapshot — run `make interop-list` or see [`implementations.json`](./implementations.json) for the current state. See [IMPLEMENTATIONS.md](./IMPLEMENTATIONS.md) for how to add your implementation.
 
@@ -127,6 +127,7 @@ See [docs/tests/TEST-CASES.md](./docs/tests/TEST-CASES.md) for detailed specific
 - [moq](https://github.com/moq-dev/moq) - Luke Curley (Rust + TypeScript)
 - [imquic](https://github.com/meetecho/imquic) - Meetecho (C)
 - [MOQtail](https://github.com/moqtail/moqtail) - OzU (Rust + TypeScript)
+- [moq-go](https://github.com/floatdrop/moq-go) - Vsevolod Strukchinsky (Go)
 
 ### Inspiration
 

--- a/builds/moq-go/build.sh
+++ b/builds/moq-go/build.sh
@@ -1,0 +1,316 @@
+#!/bin/bash
+# build.sh - Build moq-go Docker images from source
+#
+# Usage:
+#   ./build.sh                       # Clone from default ref (draft-18)
+#   ./build.sh --ref feature-branch  # Clone specific branch/tag/commit
+#   ./build.sh --repo URL            # Clone from a different repository (fork)
+#   ./build.sh --local ~/moq-go      # Use local checkout
+#   ./build.sh --target relay        # Build only relay image
+#   ./build.sh --target client       # Build only client image
+#
+# Unlike most build integrations, moq-go ships its own interop Dockerfiles and
+# entrypoints in-tree (cmd/relay/Dockerfile + cmd/relay/entrypoint-relay.sh,
+# cmd/interop-client/Dockerfile.client). Both follow the runner conventions
+# (/certs/cert.pem + /certs/priv.key, MOQT_* env, TAP v14, exit 0/1/127), so
+# this script only selects the source and invokes the in-tree Dockerfiles with
+# the repository root as the build context.
+
+set -euo pipefail
+
+#############################################################################
+# Configuration (implementation-specific)
+#############################################################################
+
+IMPL_NAME="moq-go"
+REPO_URL="https://github.com/floatdrop/moq-go"
+DEFAULT_REF="draft-18"
+
+# Build directory (where this script lives)
+BUILD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCES_DIR="${BUILD_DIR}/.sources"
+RUNNER_ROOT="$(cd "${BUILD_DIR}/../.." && pwd)"
+
+#############################################################################
+# Utility Functions (candidates for shared library)
+#############################################################################
+
+log() {
+    echo "[build] $*" >&2
+}
+
+error() {
+    echo "[build] ERROR: $*" >&2
+    exit 1
+}
+
+# Get git commit hash from a directory
+get_git_commit() {
+    local dir="$1"
+    git -C "$dir" rev-parse HEAD 2>/dev/null || echo "unknown"
+}
+
+# Check if git working directory is dirty
+is_git_dirty() {
+    local dir="$1"
+    if git -C "$dir" diff --quiet HEAD 2>/dev/null && \
+       git -C "$dir" diff --cached --quiet HEAD 2>/dev/null; then
+        echo "false"
+    else
+        echo "true"
+    fi
+}
+
+# Get current timestamp in ISO 8601 format
+get_timestamp() {
+    date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+# Get the moq-interop-runner repo commit
+get_runner_commit() {
+    git -C "$RUNNER_ROOT" rev-parse HEAD 2>/dev/null || echo "unknown"
+}
+
+#############################################################################
+# Argument Parsing
+#############################################################################
+
+REF=""
+LOCAL_PATH=""
+TARGET=""  # empty = build all targets
+CUSTOM_REPO=""  # override REPO_URL
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --ref)
+            if [[ -z "${2:-}" ]]; then
+                error "--ref requires a value"
+            fi
+            REF="$2"
+            shift 2
+            ;;
+        --repo)
+            if [[ -z "${2:-}" ]]; then
+                error "--repo requires a value"
+            fi
+            CUSTOM_REPO="$2"
+            shift 2
+            ;;
+        --local)
+            if [[ -z "${2:-}" ]]; then
+                error "--local requires a value"
+            fi
+            LOCAL_PATH="$2"
+            shift 2
+            ;;
+        --target)
+            if [[ -z "${2:-}" ]]; then
+                error "--target requires a value"
+            fi
+            TARGET="$2"
+            shift 2
+            ;;
+        --help|-h)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --ref REF       Git ref to checkout (branch/tag/commit)"
+            echo "  --repo URL      Clone from a different repository (fork)"
+            echo "  --local PATH    Use local checkout instead of cloning"
+            echo "  --target NAME   Build only specific target (relay|client)"
+            echo "  --help          Show this help"
+            echo ""
+            echo "Examples:"
+            echo "  $0                           # Clone default branch (${DEFAULT_REF})"
+            echo "  $0 --ref v0.5.0              # Clone specific tag"
+            echo "  $0 --repo https://github.com/user/moq-go --ref branch"
+            echo "  $0 --local ~/moq-go          # Use local checkout"
+            echo "  $0 --local ~/moq-go --target relay"
+            exit 0
+            ;;
+        *)
+            error "Unknown option: $1"
+            ;;
+    esac
+done
+
+# Apply --repo override if specified
+if [[ -n "$CUSTOM_REPO" ]]; then
+    REPO_URL="$CUSTOM_REPO"
+fi
+
+# Validate: can't specify both --ref and --local
+if [[ -n "$REF" && -n "$LOCAL_PATH" ]]; then
+    error "Cannot specify both --ref and --local"
+fi
+
+# Validate: --repo only makes sense with --ref (not --local)
+if [[ -n "$CUSTOM_REPO" && -n "$LOCAL_PATH" ]]; then
+    error "Cannot specify both --repo and --local"
+fi
+
+# Default to cloning if neither specified
+if [[ -z "$REF" && -z "$LOCAL_PATH" ]]; then
+    REF="$DEFAULT_REF"
+fi
+
+#############################################################################
+# Source Preparation
+#############################################################################
+
+if [[ -n "$LOCAL_PATH" ]]; then
+    # Using local checkout
+    if [[ ! -d "$LOCAL_PATH" ]]; then
+        error "Local path does not exist: $LOCAL_PATH"
+    fi
+    SOURCE_DIR="$(cd "$LOCAL_PATH" && pwd)"
+    SOURCE_TYPE="local"
+    log "Using local checkout: $SOURCE_DIR"
+else
+    # Clone from remote
+    SOURCE_DIR="${SOURCES_DIR}/${IMPL_NAME}"
+    SOURCE_TYPE="git"
+
+    mkdir -p "$SOURCES_DIR"
+
+    if [[ -d "$SOURCE_DIR/.git" ]]; then
+        EXISTING_URL=$(git -C "$SOURCE_DIR" remote get-url origin 2>/dev/null || echo "")
+        if [[ "$EXISTING_URL" != "$REPO_URL" ]]; then
+            log "Repo URL changed ($EXISTING_URL -> $REPO_URL), re-cloning..."
+            rm -rf "$SOURCE_DIR"
+            git clone "$REPO_URL" "$SOURCE_DIR"
+        else
+            log "Updating existing clone..."
+            git -C "$SOURCE_DIR" fetch origin
+        fi
+    else
+        log "Cloning $REPO_URL..."
+        rm -rf "$SOURCE_DIR"
+        git clone "$REPO_URL" "$SOURCE_DIR"
+    fi
+
+    log "Checking out ref: $REF"
+    git -C "$SOURCE_DIR" checkout "$REF"
+    git -C "$SOURCE_DIR" pull origin "$REF" 2>/dev/null || true
+fi
+
+# Capture source provenance
+SOURCE_COMMIT=$(get_git_commit "$SOURCE_DIR")
+SOURCE_DIRTY=$(is_git_dirty "$SOURCE_DIR")
+
+#############################################################################
+# Docker Builds
+#
+# moq-go's Dockerfiles live in-tree and expect the repository root as the build
+# context (they COPY go.mod/go.sum and the full module). We point `docker build
+# -f <source>/<dockerfile> <source>` so no files are copied into builds/moq-go.
+#
+# If your network uses TLS inspection, place your CA certificate at
+# builds/moq-go/extra-ca.pem and it will be trusted during the build.
+#############################################################################
+
+BUILT_IMAGES=()
+
+# Check for extra CA cert (useful for networks with TLS inspection)
+CA_CERT_FILE="${BUILD_DIR}/extra-ca.pem"
+SECRET_ARGS=""
+if [[ -f "$CA_CERT_FILE" ]]; then
+    log "Found extra CA certificate: $CA_CERT_FILE"
+    SECRET_ARGS="--secret id=ca_cert,src=${CA_CERT_FILE}"
+fi
+
+build_target() {
+    local target="$1"
+    local dockerfile=""
+    local image_name=""
+
+    case "$target" in
+        relay)
+            dockerfile="${SOURCE_DIR}/cmd/relay/Dockerfile"
+            image_name="moq-go-relay"
+            ;;
+        client)
+            dockerfile="${SOURCE_DIR}/cmd/interop-client/Dockerfile.client"
+            image_name="moq-go-client"
+            ;;
+        *)
+            error "Unknown target: $target"
+            ;;
+    esac
+
+    if [[ ! -f "$dockerfile" ]]; then
+        error "Dockerfile not found: $dockerfile (is the moq-go checkout up to date?)"
+    fi
+
+    log "Building ${target} -> ${image_name}:latest"
+    log "  Dockerfile: ${dockerfile}"
+    log "  Context: ${SOURCE_DIR}"
+
+    # shellcheck disable=SC2086
+    if docker build \
+        -f "${dockerfile}" \
+        $SECRET_ARGS \
+        -t "${image_name}:latest" \
+        "$SOURCE_DIR"; then
+        :
+    else
+        error "Docker build failed for ${target}"
+    fi
+
+    BUILT_IMAGES+=("{\"target\": \"${target}\", \"image\": \"${image_name}:latest\"}")
+}
+
+if [[ -n "$TARGET" ]]; then
+    build_target "$TARGET"
+else
+    build_target "relay"
+    build_target "client"
+fi
+
+#############################################################################
+# Provenance Output
+#############################################################################
+
+TIMESTAMP=$(get_timestamp)
+RUNNER_COMMIT=$(get_runner_commit)
+IMAGES_JSON=$(IFS=,; echo "${BUILT_IMAGES[*]}")
+
+# Use jq for safe JSON generation to avoid injection issues
+# shellcheck disable=SC2016
+PROVENANCE=$(jq -n \
+    --arg impl "$IMPL_NAME" \
+    --arg ts "$TIMESTAMP" \
+    --arg runner_commit "$RUNNER_COMMIT" \
+    --arg source_type "$SOURCE_TYPE" \
+    --arg repo "$REPO_URL" \
+    --arg ref "${REF:-}" \
+    --arg local_path "${LOCAL_PATH:-}" \
+    --arg commit "$SOURCE_COMMIT" \
+    --argjson dirty "$SOURCE_DIRTY" \
+    --argjson images "[$IMAGES_JSON]" \
+    '{
+        implementation: $impl,
+        timestamp: $ts,
+        runner_commit: $runner_commit,
+        source: {
+            type: $source_type,
+            repository: $repo,
+            ref: (if $ref == "" then "local" else $ref end),
+            local_path: (if $local_path == "" then null else $local_path end),
+            commit: $commit,
+            dirty: $dirty
+        },
+        images: $images
+    }'
+)
+
+# Save to file
+echo "$PROVENANCE" > "${BUILD_DIR}/.last-build.json"
+log "Provenance saved to ${BUILD_DIR}/.last-build.json"
+
+# Output to stdout for capture
+echo ""
+echo "=== Build Provenance ==="
+echo "$PROVENANCE"
+
+log "Build complete!"

--- a/builds/moq-go/config.json
+++ b/builds/moq-go/config.json
@@ -1,0 +1,18 @@
+{
+  "name": "moq-go",
+  "description": "Go implementation of MoQT (draft-18): session library, reference relay, and interop test client",
+  "repository": "https://github.com/floatdrop/moq-go",
+  "default_ref": "draft-18",
+  "targets": {
+    "relay": {
+      "dockerfile": ".sources/moq-go/cmd/relay/Dockerfile",
+      "image_name": "moq-go-relay",
+      "context": ".sources/moq-go"
+    },
+    "client": {
+      "dockerfile": ".sources/moq-go/cmd/interop-client/Dockerfile.client",
+      "image_name": "moq-go-client",
+      "context": ".sources/moq-go"
+    }
+  }
+}

--- a/implementations.json
+++ b/implementations.json
@@ -166,6 +166,37 @@
         }
       }
     },
+    "moq-go": {
+      "name": "moq-go",
+      "organization": "floatdrop",
+      "repository": "https://github.com/floatdrop/moq-go",
+      "draft_versions": [
+        "draft-18"
+      ],
+      "notes": "Go implementation of MoQT (draft-ietf-moq-transport-18): transport-agnostic session library, single-instance reference relay, and an interop test client. Both relay and client images are built in-tree (cmd/relay, cmd/interop-client) and follow the runner conventions.",
+      "roles": {
+        "relay": {
+          "docker": {
+            "image": "moq-go-relay:latest",
+            "build": {
+              "dockerfile": ".sources/moq-go/cmd/relay/Dockerfile",
+              "context": "builds/moq-go/.sources/moq-go"
+            },
+            "notes": "Build from source: make build-impl IMPL=moq-go BUILD_ARGS=\"--target relay\" (add --local ~/moq-go to use a local checkout)."
+          }
+        },
+        "client": {
+          "docker": {
+            "image": "moq-go-client:latest",
+            "build": {
+              "dockerfile": ".sources/moq-go/cmd/interop-client/Dockerfile.client",
+              "context": "builds/moq-go/.sources/moq-go"
+            },
+            "notes": "Build from source: make build-impl IMPL=moq-go BUILD_ARGS=\"--target client\" (add --local ~/moq-go to use a local checkout)."
+          }
+        }
+      }
+    },
     "moq-rs": {
       "name": "moq-rs",
       "organization": "Cloudflare",


### PR DESCRIPTION
moq-go ships its own runner-compatible Dockerfiles and entrypoints in-tree, so the integration only needs runner-side wiring:

- builds/moq-go/{build.sh,config.json}: source selection (--local / --ref / --repo / --target) that invokes moq-go's in-tree Dockerfiles with the repo root as build context
- implementations.json: moq-go entry advertising draft-18, relay + client roles
- Makefile: build-moq-go convenience target (+ .PHONY/help)
- README.md: implementations table row