### PR TITLE
Fix nightly Interop Report timeout: additive report generation + dry-run validation

### DIFF
--- a/.github/workflows/interop-report.yml
+++ b/.github/workflows/interop-report.yml
@@ -9,20 +9,44 @@ on:
         description: 'Build source-based images from scratch instead of pulling pre-built from GHCR'
         type: boolean
         default: false
+      dry_run:
+        description: 'Validate the report/publish path without pushing to gh-pages (artifact + summary only)'
+        type: boolean
+        default: false
+  pull_request:
+    # Self-validation for changes to the report/publish machinery (like this
+    # one). Path-scoped to reporter/workflow files so it runs on harness PRs
+    # but NOT on the common contributor registration PR (implementations.json),
+    # which gets its own schema gate in a later PR.
+    paths:
+      - '.github/workflows/interop-report.yml'
+      - 'generate-report.sh'
+      - 'lib/**'
 
 
+# Least privilege by default: read-only. Only the nightly publish job is
+# granted write access (below), so the dry-run job can never push to gh-pages.
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
-  group: interop-report
+  # Separate group per ref so dry-runs never queue behind / cancel the nightly
+  # (which always runs on the default branch).
+  group: interop-report-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
   test-and-publish:
-    if: github.repository == 'englishm/moq-interop-runner'
+    # Publishes for effect: nightly schedule, or a maintainer dispatch that is
+    # NOT a dry-run. Never on pull_request.
+    if: >-
+      github.repository == 'englishm/moq-interop-runner' &&
+      github.event_name != 'pull_request' &&
+      !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: write  # publishes to gh-pages
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -125,4 +149,94 @@ jobs:
           git add .
           git commit -m "Add interop results for $TIMESTAMP"
           git push origin gh-pages
+
+  dry-run-report:
+    # Validates the report/publish path without touching the live site. It
+    # exercises the real nightly publish logic (index + one new detail) against
+    # the already-published results, ASSERTS the additive property (no existing
+    # detail report is rewritten — the regression that caused the timeout),
+    # reports generation time + a result summary inline, and uploads the
+    # rendered site as an artifact. Read-only: it can never push to gh-pages.
+    #
+    # Runs automatically on reporter/workflow PRs, and on a maintainer
+    # `workflow_dispatch` with dry_run=true (dispatch requires write access).
+    if: >-
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'workflow_dispatch' && inputs.dry_run)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout ref
+        uses: actions/checkout@v4
+        with:
+          path: main
+
+      - name: Checkout gh-pages (published results)
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages-site
+
+      - name: Regenerate report and validate additive behavior
+        working-directory: gh-pages-site
+        run: |
+          set -euo pipefail
+          cp ../main/generate-report.sh .
+          cp -r ../main/lib .
+
+          LATEST=$(ls -1d results/*/ 2>/dev/null | sort | tail -1 | xargs -r basename || true)
+          if [ -z "${LATEST:-}" ]; then
+            echo "No published results to render — nothing to validate." | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Synthesize a fresh run from the latest one so we exercise the real
+          # nightly path: generate the index + ONE new detail report.
+          NEWTS="dryrun-preview"
+          rm -rf "results/$NEWTS"
+          cp -r "results/$LATEST" "results/$NEWTS"
+
+          start=$(date +%s)
+          ./generate-report.sh "results/$NEWTS"
+          elapsed=$(( $(date +%s) - start ))
+
+          mv results/index.html index.html
+          sed -i 's|href="\([0-9]\{4\}-\)|href="results/\1|g' index.html
+          sed -i 's|href="../index.html"|href="../../index.html"|g' results/*/report.html
+          rm generate-report.sh
+          rm -rf lib
+
+          # Assert additive: no PRE-EXISTING detail report may be modified.
+          modified_existing=$(git diff --name-only -- 'results/**/report.html' \
+            | { grep -v "results/$NEWTS/" || true; } | wc -l | tr -d ' ')
+          scanned=$(ls -1d results/*/ | { grep -v "results/$NEWTS/" || true; } | wc -l | tr -d ' ')
+
+          {
+            echo "## Interop report — additive publish dry-run"
+            echo ""
+            echo "| Check | Value |"
+            echo "|---|---|"
+            echo "| Published runs scanned | $scanned |"
+            echo "| Generation time (index + 1 new detail) | ${elapsed}s |"
+            echo "| Pre-existing detail reports modified | $modified_existing (expected 0) |"
+            echo ""
+            if [ "$modified_existing" -eq 0 ]; then
+              echo "✅ **Additive** — regenerating touched only the new run + index."
+            else
+              echo "❌ **Not additive** — $modified_existing existing report(s) rewritten. This is the regression that stalls the nightly."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          [ "$modified_existing" -eq 0 ]
+
+      - name: Upload rendered site
+        uses: actions/upload-artifact@v4
+        with:
+          name: report-preview
+          path: |
+            gh-pages-site
+            !gh-pages-site/.git
+          retention-days: 7
 

--- a/.github/workflows/interop-report.yml
+++ b/.github/workflows/interop-report.yml
@@ -104,7 +104,11 @@ jobs:
           cp -r main/lib gh-pages-site/
 
           cd gh-pages-site
-          ./generate-report.sh
+          # Additive: only (re)generate the index + the detail report for the
+          # new run. Old detail reports are immutable and already committed, so
+          # regenerating all ~150 of them every night was the main cause of the
+          # Publish step blowing past the 60-min job timeout.
+          ./generate-report.sh "results/$TIMESTAMP"
 
           mv results/index.html index.html
           # Safer replacement: only modify hrefs that look like dates (YYYY-)


### PR DESCRIPTION
## Problem

The nightly **Interop Report** job has been hitting `timeout-minutes: 60` and getting **cancelled mid-publish for the last several days** — results are computed but never committed to gh-pages.

Per-step timings (cancelled run 2026-06-25):

| Step | Time |
|------|------|
| Run interop tests | ~40 min |
| **Publish results** | **~20 min** → cancelled at the wall |

Root cause: the Publish step regenerated a **full HTML detail report for every one of ~146 published runs on every run** (`generate-report.sh` with no args), even though old detail reports never change. That's O(N) and growing — locally it doesn't even finish in 2 minutes.

## Fix

**1. Additive publish (the actual fix).** Regenerate only the index + the *new* run's detail:

```diff
-          ./generate-report.sh
+          ./generate-report.sh "results/$TIMESTAMP"
```

Verified against the real 146-dir gh-pages tree: the index still lists **every** run, only the new detail is written, and **0** existing reports are modified (`git diff`: 198 files changed, all insertions, all under the new run dir + `index.html`). Publish drops from ~20 min → ~1 min.

**2. A read-only dry-run job that *proves* the fix and guards it.** On reporter/workflow PRs (path-scoped — *not* `implementations.json`) and on maintainer `workflow_dispatch -f dry_run=true`, a `dry-run-report` job re-runs the publish path against the published results, **asserts the additive property** (no pre-existing detail report is rewritten — fails the check if it regresses), reports gen time + a summary to the job summary, and uploads the rendered site as an artifact. It has **read-only** permissions and **never pushes** to gh-pages.

## Safety / governance

- Default workflow permission is now `contents: read`; only the nightly publish job gets `write`.
- The nightly job is gated off `pull_request` and off dry-run dispatch, so a PR can never publish.
- `workflow_dispatch` requires write access, so dry-run validation and run-for-effect are both **maintainer-only**. Plain dispatch (`dry_run=false`) still publishes for effect.
- Per-ref concurrency so dry-runs never queue behind / cancel the nightly.

## Not in this PR (follow-ups)

- Landing page: recent-results-first + browse/archive older runs (keep 30 days live, tar-archive older).
- PR CI for registration changes (schema gate + label-triggered live interop of the changed impl, with an inline markdown matrix).
- Multi-version pills per matrix cell.