### PR TITLE
Use GHCR-qualified image names for moq-go

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -204,7 +204,7 @@
       "roles": {
         "relay": {
           "docker": {
-            "image": "moq-go-relay:latest",
+            "image": "ghcr.io/englishm/moq-interop-runner-moq-go-relay:latest",
             "build": {
               "dockerfile": ".sources/moq-go/cmd/relay/Dockerfile",
               "context": "builds/moq-go/.sources/moq-go"
@@ -214,7 +214,7 @@
         },
         "client": {
           "docker": {
-            "image": "moq-go-client:latest",
+            "image": "ghcr.io/englishm/moq-interop-runner-moq-go-client:latest",
             "build": {
               "dockerfile": ".sources/moq-go/cmd/interop-client/Dockerfile.client",
               "context": "builds/moq-go/.sources/moq-go"


### PR DESCRIPTION
## Problem

After moq-go was merged, every moq-go combination in the nightly interop matrix is marked **SKIP with no logs**.

Root cause is an image-name mismatch, not a test failure. The nightly `interop-report.yml` only pulls pre-built images whose `docker.image` starts with `ghcr.io/`:

```sh
jq -r '.implementations[].roles[].docker.image // empty' implementations.json | grep '^ghcr.io/' | ... docker pull ...
```

moq-go was the only source-built implementation referencing **bare local tags** (`moq-go-relay:latest` / `moq-go-client:latest`). Those don't match the `^ghcr.io/` filter, so they're never pulled; `docker image inspect` then fails and `run-interop-tests.sh` records `status: "skip"` (`skip_reason="relay/client image unavailable"`) — the test never runs, hence no logs.

## Fix

Point `implementations.json` at the GHCR names that `build-images.yml` actually pushes, matching every other source-built implementation:

- relay → `ghcr.io/englishm/moq-interop-runner-moq-go-relay:latest`
- client → `ghcr.io/englishm/moq-interop-runner-moq-go-client:latest`

The `build` blocks and the local build tags used by `make build-impl` are unchanged.

## Verification

- JSON validates (`jq -e`).
- Both GHCR images already exist (`latest` + `20260626-222704`), so the next nightly can pull them without re-dispatching `build-images.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)