### PR TITLE
interop-report: raise job timeout 60->120 min

### DIFF
--- a/.github/workflows/interop-report.yml
+++ b/.github/workflows/interop-report.yml
@@ -44,9 +44,6 @@ jobs:
       github.event_name != 'pull_request' &&
       !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
     runs-on: ubuntu-latest
-    # Test phase has crept up to ~55-57 min (06-26 was cancelled at the 60-min wall).
-    # Publishing is additive/fast now, so a long test phase no longer risks corrupting
-    # gh-pages — give headroom here while sharding the test phase is pursued separately.
     timeout-minutes: 120
     permissions:
       contents: write  # publishes to gh-pages

--- a/.github/workflows/interop-report.yml
+++ b/.github/workflows/interop-report.yml
@@ -44,7 +44,10 @@ jobs:
       github.event_name != 'pull_request' &&
       !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Test phase has crept up to ~55-57 min (06-26 was cancelled at the 60-min wall).
+    # Publishing is additive/fast now, so a long test phase no longer risks corrupting
+    # gh-pages — give headroom here while sharding the test phase is pursued separately.
+    timeout-minutes: 120
     permissions:
       contents: write  # publishes to gh-pages
     steps:


### PR DESCRIPTION
The nightly test phase has crept to ~55-57 min and **2026-06-26 was cancelled at the 60-min wall**. This raises `test-and-publish` `timeout-minutes` 60 -> 120 (GH-hosted allows up to 360).

Safe because publishing is already additive/fast (PR #90), so a long test phase no longer risks a mid-publish corruption of gh-pages — the timeout only ever risked *no results that night*.

This is a symptom-fix; the durable fix is **sharding the test phase** (as built for the version-pinned runner). One-line change, isolated from the version-pinned POC PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)