### PR TITLE
Advertise draft-18 for moqx; add draft-14 to aiomoqt relay

### DIFF
--- a/adapters/aiomoqt/Dockerfile.relay
+++ b/adapters/aiomoqt/Dockerfile.relay
@@ -16,12 +16,12 @@
 FROM ghcr.io/gmarzot/aiomoqt:latest
 
 # The image's entrypoint reads these (docker-entrypoint.sh): relay role,
-# draft-16 + draft-18 (advertises both WT-protocols, server negotiates),
-# WebTransport (no MOQT_QUIC). Certs default to /certs/cert.pem +
-# /certs/priv.key.
+# draft-14/16/18 (advertises all; server negotiates), WebTransport (no MOQT_QUIC).
+# Certs default to /certs/cert.pem + /certs/priv.key. draft-14 is appended (kept
+# last) so it is offered to draft-14-only peers without changing the 16/18 order.
 ENV MOQT_ROLE=relay
 ENV MOQT_PORT=4443
-ENV MOQT_DRAFT=16,18
+ENV MOQT_DRAFT=16,18,14
 
 EXPOSE 4443/udp
 

--- a/adapters/aiomoqt/Dockerfile.relay.quic
+++ b/adapters/aiomoqt/Dockerfile.relay.quic
@@ -15,10 +15,11 @@
 FROM ghcr.io/gmarzot/aiomoqt:latest
 
 # Entrypoint (docker-entrypoint.sh): relay role, raw QUIC (MOQT_QUIC set
-# → --quic), draft-16/18. Certs default to /certs/cert.pem + /certs/priv.key.
+# → --quic), draft-14/16/18. Certs default to /certs/cert.pem + /certs/priv.key.
+# draft-14 appended (kept last) for draft-14-only peers; 16/18 order unchanged.
 ENV MOQT_ROLE=relay
 ENV MOQT_PORT=4443
-ENV MOQT_DRAFT=16,18
+ENV MOQT_DRAFT=16,18,14
 ENV MOQT_QUIC=1
 
 EXPOSE 4443/udp

--- a/adapters/moqx/Dockerfile.client
+++ b/adapters/moqx/Dockerfile.client
@@ -1,0 +1,15 @@
+# moqx client adapter for MoQT interop testing
+#
+# Wraps the published moqx interop client with one interop-testing default: it
+# advertises draft-18 first so negotiation lands on 18 when both sides support it.
+# The moqx binary's own default lists 16 first, so unconfined runs otherwise cap at
+# 16 even when 18 is available. (A pinned runner can still override
+# MOQX_MOQT_VERSIONS to a single draft for version confinement.)
+#
+# Build:
+#   docker build -t moqx-interop-client:latest -f adapters/moqx/Dockerfile.client adapters/moqx/
+#
+# Usage: same as the upstream client (reads RELAY_URL / certs from the runner).
+FROM ghcr.io/openmoq/moqx-interop-client:latest
+
+ENV MOQX_MOQT_VERSIONS=18,16,14

--- a/adapters/moqx/Dockerfile.relay
+++ b/adapters/moqx/Dockerfile.relay
@@ -18,6 +18,11 @@ ENV MOQX_BIND_ADDR=0.0.0.0
 ENV MOQX_CERT=/certs/cert.pem
 ENV MOQX_KEY=/certs/priv.key
 ENV MOQX_ENDPOINT=/
+# Advertise draft-18 first so negotiation lands on 18 when mutually supported.
+# moqx's binary default lists 16 first, so unconfined runs pick 16 even when 18
+# is available; ordering 18,16,14 fixes that. (A pinned runner can still override
+# MOQX_MOQT_VERSIONS to a single draft for version confinement.)
+ENV MOQX_MOQT_VERSIONS=18,16,14
 
 EXPOSE 4443/udp
 

--- a/implementations.json
+++ b/implementations.json
@@ -487,8 +487,7 @@
       "repository": "https://github.com/facebookexperimental/moxygen",
       "draft_versions": [
         "draft-14",
-        "draft-16",
-        "draft-18"
+        "draft-16"
       ],
       "notes": "C++ implementation. Supports multiple draft versions simultaneously via version negotiation.",
       "roles": {

--- a/implementations.json
+++ b/implementations.json
@@ -28,10 +28,11 @@
       "organization": "MarzResearch",
       "repository": "https://github.com/gmarzot/aiomoqt",
       "draft_versions": [
+        "draft-14",
         "draft-16",
         "draft-18"
       ],
-      "notes": "aiomoqt server-side control plane over WebTransport (draft-16/18): SETUP, PUBLISH_NAMESPACE, SUBSCRIBE. No object forwarding.",
+      "notes": "aiomoqt server-side control plane over WebTransport (draft-14/16/18): SETUP, PUBLISH_NAMESPACE, SUBSCRIBE. No object forwarding.",
       "roles": {
         "relay": {
           "docker": {
@@ -52,6 +53,7 @@
       "organization": "MarzResearch",
       "repository": "https://github.com/gmarzot/aiomoqt",
       "draft_versions": [
+        "draft-14",
         "draft-16",
         "draft-18"
       ],
@@ -424,8 +426,8 @@
       "repository": "https://github.com/openmoq/moqx",
       "draft_versions": [
         "draft-14",
-        "draft-15",
-        "draft-16"
+        "draft-16",
+        "draft-18"
       ],
       "notes": "C++ relay built on moxygen. Supports multiple draft versions via version negotiation.",
       "roles": {
@@ -454,7 +456,12 @@
         },
         "client": {
           "docker": {
-            "image": "ghcr.io/openmoq/moqx-interop-client:latest"
+            "image": "moqx-interop-client:latest",
+            "build": {
+              "dockerfile": "adapters/moqx/Dockerfile.client",
+              "context": "adapters/moqx"
+            },
+            "upstream_image": "ghcr.io/openmoq/moqx-interop-client:latest"
           }
         },
         "publisher": {
@@ -480,7 +487,8 @@
       "repository": "https://github.com/facebookexperimental/moxygen",
       "draft_versions": [
         "draft-14",
-        "draft-16"
+        "draft-16",
+        "draft-18"
       ],
       "notes": "C++ implementation. Supports multiple draft versions simultaneously via version negotiation.",
       "roles": {


### PR DESCRIPTION
Every recent official nightly caps **moqx at draft-16**, skips draft-18-only clients (moq-go, moq-rs-draft-18) against moqx, and **moq-rs never pairs with aiomoqt**. The official runner uses each impl's image default (it ignores `docker.env`) and labels results with the *predicted* negotiated version, so two gaps block/cap those pairings:

| impl | was | now | why |
|---|---|---|---|
| moqx (relay+client) | `14,15,16` | `14,16,18` | supports 18 but omitted it → d18 clients skip it |
| aiomoqt-relay(+quic) | `16,18` | `14,16,18` | no 14 → moq-rs (14-only) skips it |

Plus moqx advertises **16 first** (`16,14,18`), so even with 18 declared it negotiates 16 — which the runner would then **mislabel as 18**.

### Changes
- **Registration**: moqx → `14,16,18` (dropped stale `draft-15` — the live endpoint advertises 14/16/18); aiomoqt-relay + aiomoqt-relay-quic → `14,16,18`.
- **`adapters/moqx/Dockerfile.relay`**: `ENV MOQX_MOQT_VERSIONS=18,16,14` → negotiation reaches 18 (label == wire).
- **`adapters/moqx/Dockerfile.client`** (new): same; moqx client was a raw pulled image with no version default → now a built adapter (`make build-adapters`).
- **`adapters/aiomoqt/Dockerfile.relay(.quic)`**: append `14` (`16,18,14`) so draft-14-only peers pair; 16/18 order unchanged.

Backward compatible — baked defaults only affect the *unconfined* advertisement; a version-pinned runner can still override per draft. Schema validates; new client adapter builds.

### Split out
- **moxygen** draft-18 (also real — fb.mvfst.net advertises 14/16/18) is Meta-owned and goes in its **own PR** for separate review.
- Upstream `openmoq/moqx` (openmoq/moqx#472): make the binary default prefer the latest draft, so the adapter override becomes belt-and-suspenders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
