### PR TITLE
moxygen: declare draft-18 support

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -480,7 +480,8 @@
       "repository": "https://github.com/facebookexperimental/moxygen",
       "draft_versions": [
         "draft-14",
-        "draft-16"
+        "draft-16",
+        "draft-18"
       ],
       "notes": "C++ implementation. Supports multiple draft versions simultaneously via version negotiation.",
       "roles": {


### PR DESCRIPTION
moxygen supports **draft-18**, but its registration lists only `[14,16]`. The official (negotiated) runner computes "no shared version" from `draft_versions`, so **draft-18-only clients (moq-go, moq-rs-draft-18) are never tested against moxygen**, and 18-capable clients get capped at 16.

### Change
`implementations.json`: `moxygen.draft_versions` `[14,16]` → `[14,16,18]`. One line, no adapter change — moxygen already advertises and negotiates 18 (no version env knob needed).

### Verified
Probed the public endpoint (aiomoqt relay_probe):
```
https://fb.mvfst.net:9448/moq-relay   H3/WT  ✓  draft-14,draft-16,draft-18
moqt://fb.mvfst.net:9448               QUIC   ✓  draft-14,draft-16,draft-18
```
Both transports advertise 18, and the local `moxygen-interop` image passes `moxygen→moxygen @18 = 6/6`.

Split out from englishm/moq-interop-runner#99 so Meta can review the moxygen change separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)