### PR TITLE
imquic: reference GHCR image names so the nightly can pull them

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -96,14 +96,14 @@
             }
           ],
           "docker": {
-            "image": "imquic-moq-relay",
-            "notes": "Build from source: ./builds/imquic/build.sh --target relay"
+            "image": "ghcr.io/englishm/moq-interop-runner-imquic-moq-relay:latest",
+            "notes": "Build from source: ./builds/imquic/build.sh --target relay (published to GHCR via build-images.yml)"
           }
         },
         "client": {
           "docker": {
-            "image": "imquic-moq-interop-test",
-            "notes": "Build from source: ./builds/imquic/build.sh --target client"
+            "image": "ghcr.io/englishm/moq-interop-runner-imquic-moq-interop-test:latest",
+            "notes": "Build from source: ./builds/imquic/build.sh --target client (published to GHCR via build-images.yml)"
           }
         }
       }


### PR DESCRIPTION
imquic's images **are** built and pushed to GHCR by `build-images.yml`, but its `implementations.json` entry still referenced **bare local tags** (`imquic-moq-relay`, `imquic-moq-interop-test`). Since [`1a01efb2`](https://github.com/englishm/moq-interop-runner/commit/1a01efb2) the nightly's default path pulls **only** `ghcr.io/*` images (`grep '^ghcr.io/'`) and no longer builds from source, so imquic's images were never fetched → imquic skipped every official run (*"image unavailable"*), which also produced the imquic→aiomoqt-relay skips.

Worth noting for context: the bare-tag form is what the contributor docs still prescribe ([IMPLEMENTATIONS.md](../blob/main/IMPLEMENTATIONS.md), [docs/DOCKER-TESTING.md](../blob/main/docs/DOCKER-TESTING.md)), and several other impls (`aiomoqt (relay)`, `moq-dev-rs`, `moq-go`, `moqx`, `moxygen`) use it too — so this isn't unique to imquic and isn't a registration mistake. imquic just *also* has GHCR-published images that its entry wasn't pointing at, so pointing it at them is a clean, immediate fix.

**Fix:** point at the GHCR names that `build-images.yml` publishes:
- relay → `ghcr.io/englishm/moq-interop-runner-imquic-moq-relay:latest` — **exists**, works immediately.
- client → `ghcr.io/englishm/moq-interop-runner-imquic-moq-interop-test:latest` — **needs a `build-images.yml` → `imquic-client` run** to populate the GHCR tag (it isn't there yet).

After merge: the imquic **relay** pairs run right away; the imquic **client** pairs run once `build-images.yml` has built+pushed the client image once.

**Follow-up (out of scope for this PR):** the docs still describe the pre-`1a01efb2` source-build model. Either update IMPLEMENTATIONS.md / DOCKER-TESTING.md to state that impls participating in the nightly need GHCR-qualified names, or restore a source-build fallback — and audit the other bare-tag impls above for the same silent skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
