### PR TITLE
spec: define direct PUBLISH lifecycle tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ SHELL := /bin/bash
 .PHONY: test test-verbose test-single test-external clean mlog-clean certs \
         interop-all interop-docker interop-remote interop-relay interop-client interop-list \
         relay-start relay-stop logs logs-relay logs-client \
-        build-adapters build-moxygen-adapter build-impl build-moq-rs build-moq-go report help _ensure-certs \
+        build-adapters build-moxygen-adapter build-impl build-moq-rs build-moq-go report validate-target-draft test-target-draft-validator help _ensure-certs \
         xquic-client-build xquic-client-test-draft18 xquic-relay-build
 
 #############################################################################
@@ -261,6 +261,13 @@ xquic-relay-build:
 report:
 	@./generate-report.sh
 
+# Validate canonical test specs against implementations.json.current_target.
+validate-target-draft:
+	@./scripts/validate-target-draft.sh $(if $(PREVIOUS_RETIRED),--previous-retired $(PREVIOUS_RETIRED)) $(SPEC_FILES)
+
+test-target-draft-validator:
+	@./scripts/test-validate-target-draft.sh
+
 #############################################################################
 # Help
 #############################################################################
@@ -311,6 +318,8 @@ help:
 	@echo "  relay-stop            Stop relay container"
 	@echo "  clean                 Remove containers, mlog, and certs"
 	@echo "  report                Generate HTML report from results"
+	@echo "  validate-target-draft Validate target, IDs, and retirement history"
+	@echo "  test-target-draft-validator  Test target-draft and retirement policy checks"
 	@echo ""
 	@echo "Image Configuration:"
 	@echo "  RELAY_IMAGE           Relay Docker image (default: moq-relay-ietf:latest)"

--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ report:
 
 # Validate canonical test specs against implementations.json.current_target.
 validate-target-draft:
-	@./scripts/validate-target-draft.sh $(if $(PREVIOUS_RETIRED),--previous-retired $(PREVIOUS_RETIRED)) $(SPEC_FILES)
+	@./scripts/validate-target-draft.sh $(if $(PREVIOUS_RETIRED),--previous-retired $(PREVIOUS_RETIRED)) $(if $(PREVIOUS_SPEC),--previous-spec $(PREVIOUS_SPEC)) $(SPEC_FILES)
 
 test-target-draft-validator:
 	@./scripts/test-validate-target-draft.sh

--- a/README.md
+++ b/README.md
@@ -78,10 +78,12 @@ Tests are organized by functional category:
 |------|----------|-------------|
 | `setup-only` | Session | Connect, complete SETUP exchange, close gracefully |
 | `announce-only` | Namespace | Announce namespace, receive OK, close |
-| `publish-namespace-done` | Namespace | Announce, then send PUBLISH_NAMESPACE_DONE |
+| `publish-namespace-done` | Namespace | Announce, then withdraw by cancelling the request stream |
 | `subscribe-error` | Subscription | Subscribe to non-existent track, expect error |
 | `announce-subscribe` | Subscription | Publisher announces, subscriber subscribes |
 | `subscribe-before-announce` | Subscription | Subscribe before publisher announces |
+| `publish-without-subscriber` | Track publishing | Exercise the Forward-State-aware PUBLISH lifecycle without a subscriber |
+| `publish-to-pending-subscription` | Track publishing | Deliver PUBLISH data to a subscriber-first pending request |
 
 See [docs/tests/TEST-CASES.md](./docs/tests/TEST-CASES.md) for detailed specifications with protocol references.
 

--- a/docs/TARGET-DRAFT-POLICY.md
+++ b/docs/TARGET-DRAFT-POLICY.md
@@ -4,13 +4,17 @@ Canonical test specifications describe the protocol draft selected by `implement
 
 ## Identifier Lifecycle
 
-Test IDs are designed for enduring RFC semantics, not coexistence among drafts. IDs and corresponding public function names must describe observable test meaning without version markers such as `d18`, `draft-18`, or `moqt18` anywhere in the name.
+Test IDs are designed for enduring RFC semantics, not coexistence among drafts. IDs must describe observable test meaning without version markers such as `d18`, `draft-18`, or `moqt18` anywhere in the name.
 
 Retain an ID when a new target changes only section numbers or editorial placement and the test's meaning, observable behavior, applicability, and pass criteria remain equivalent. Retention requires one atomic change that updates the target declarations, exact section references, normative links, message terminology, test vectors, and support manifests as needed.
 
-If an ID's meaning, observable behavior, applicability, or pass criteria become stale or incompatible, retire it. Never reuse a retired ID for different semantics. Introduce a new semantic ID and record the retired ID, its replacement, its last-known target draft, profile revision, implementation source, commit, and image digest in [tests/retired-test-identifiers.json](./tests/retired-test-identifiers.json). Record unavailable legacy provenance explicitly as `unknown`; do not imply that it was captured. A retired ID is a tombstone, not an alias, and test clients must not emit it as a new canonical result.
+If an ID's meaning, observable behavior, applicability, or pass criteria become stale or incompatible, retire it. Never reuse a retired ID for different semantics. Record the runner-owned retired ID, its replacement, last-known target draft, profile revision, and reason in [tests/retired-test-identifiers.json](./tests/retired-test-identifiers.json). `replacement` is the next semantic ID, which may itself later be retired, or `null` when there is explicitly no replacement. Every non-null chain must terminate at a current active ID and must not contain a cycle. A retired ID is a tombstone, not an alias, and must not count as a new canonical result. Runtime TAP/result-parser quarantine for retired IDs is a follow-up; this policy change does not add that runtime enforcement.
 
-Historical results record provenance as metadata. Each result set must identify the explicit target draft, profile revision, runner commit, driver commit, and image digest. Consumers must use that metadata rather than infer or parse a draft from an ID.
+Canonical profile and result artifacts require the explicit target draft, profile revision, runner commit, driver commit, and image digest. Legacy aggregate runner output does not yet satisfy that provenance contract and must not be described as fully reproducible. Adding complete runtime provenance is a follow-up, not present behavior. Consumers must not infer a draft or provenance from an ID.
+
+Implementation-specific parity and retirement belong in the implementation's own repository or in an optional, uniformly defined driver profile. Implementation-local names that were never canonical runner IDs do not belong in the runner retirement registry.
+
+`publish-without-subscriber` and `publish-to-pending-subscription` are new runner-owned semantic specifications. They are not runner aliases or replacements for implementation-local identifiers.
 
 ## Target Migration Checklist
 
@@ -27,7 +31,7 @@ When `implementations.json.current_target` changes, review every canonical test 
 For every existing ID, the migration review must state one of these outcomes:
 
 - **Retained**: semantics and pass criteria remain equivalent
-- **Retired/New**: the old ID's last-valid provenance and replacement are recorded, and a new semantic ID is introduced when applicable
+- **Retired/New**: the old ID's last-valid provenance and replacement, or explicit lack of replacement, are recorded
 
 Do not treat a mechanical draft-number replacement as sufficient. Automation cannot decide semantic equivalence. The `Identifier Semantics Reviewed For` declaration is a human- or agent-reviewed gate attesting that these retention and retirement decisions were made for the declared target.
 
@@ -40,8 +44,22 @@ Each canonical specification must contain exactly one declaration of each form, 
 **Identifier Semantics Reviewed For**: `draft-18`
 ```
 
-Run `make validate-target-draft`. The validator removes HTML comments and fenced code examples before checking exact declarations, canonical heading and first-column table IDs, external Rust `test_*` function identifiers, formal references, and retirement integrity. Commented or fenced declarations, IDs, functions, and replacement headings are not active. Malformed or decorated definition attempts fail instead of being ignored. The registry has an explicit format version and a stable full-record pin for its initial tombstones. Existing tombstones are immutable and the registry is append-only; `--previous-retired FILE` requires the prior tombstone array to be an exact prefix, and the Make target accepts the same path as `PREVIOUS_RETIRED=FILE`. The validator does not interpret normative target prose or links as public identifiers, and it cannot verify the semantic-equivalence judgment attested by the review declaration. Validator maintainers can run `make test-target-draft-validator` for positive and negative regression cases.
+Run `make validate-target-draft`. The validator removes HTML comments and fenced code examples before checking exact declarations, formal references, canonical test headings, table naming hygiene, and retirement integrity. Only visible `### semantic-id` headings in the primary canonical specification define active runner IDs; Markdown permits zero to three leading spaces. Tables are proposals or indexes and never define active IDs or satisfy retirement replacements. The generic retirement registry permits exactly `id`, `last_known_target`, `last_known_profile_revision`, `reason`, and `replacement` in each record and is append-only; `--previous-retired FILE` requires the prior tombstone array to be an exact prefix. `--previous-spec FILE` compares only the prior primary canonical specification and requires every removed active heading ID to have a retirement tombstone. The Make target exposes these as `PREVIOUS_RETIRED=FILE` and `PREVIOUS_SPEC=FILE`. Validator maintainers can run `make test-target-draft-validator` for positive and negative regression cases.
 
-Stacked profiles can include their canonical specs with `make validate-target-draft SPEC_FILES="path/to/profile-spec.md"` or by passing files directly to `scripts/validate-target-draft.sh`.
+## Proof Boundary
 
-The existing registration workflow runs when `implementations.json` (including `current_target`), `implementations.schema.json`, or `validate-registration.sh` changes. A registration-wrapper change therefore exercises this validator. The wrapper also passes the prior retirement snapshot for append-only comparison when `--base` contains one. The workflow does not cover spec-only, validator-only, or retirement-registry-only changes. Because its path scope cannot be expanded with the current GitHub App permission, those contributors must run `make validate-target-draft` and `make test-target-draft-validator`; do not assume broader CI coverage.
+The validator proves only that the visible runner-owned primary canonical specification agrees with `current_target`, uses valid and unique heading IDs, preserves or retires prior primary IDs, and maintains a well-formed append-only runner retirement history.
+
+It does not prove:
+
+- Implementation source parity with a canonical test
+- Test CLI availability or identifier support
+- Wire behavior or interoperability
+- Protocol conformance
+- Container image identity or provenance
+
+Automation also cannot determine semantic equivalence; the review declaration remains a human- or agent-reviewed gate.
+
+Additional specs can still be checked for target declarations, references, heading grammar, and table naming hygiene with `SPEC_FILES="path/to/profile-spec.md"`. Their lifecycle and implementation parity require the profile's own uniform validator; additional profiles cannot satisfy primary runner retirements.
+
+The existing registration workflow runs when `implementations.json` (including `current_target`), `implementations.schema.json`, or `validate-registration.sh` changes. A registration-wrapper change therefore exercises this validator. The wrapper passes prior retirement and canonical-spec snapshots from `--base` when present. The workflow does not cover spec-only, validator-only, or retirement-registry-only changes. Because its path scope cannot be expanded with the current GitHub App permission, those contributors must run `make validate-target-draft` and `make test-target-draft-validator`; do not assume broader CI coverage.

--- a/docs/TARGET-DRAFT-POLICY.md
+++ b/docs/TARGET-DRAFT-POLICY.md
@@ -1,0 +1,47 @@
+# Target-Draft Policy
+
+Canonical test specifications describe the protocol draft selected by `implementations.json.current_target`. Every canonical specification declares both its target draft and the draft for which its identifier semantics were reviewed.
+
+## Identifier Lifecycle
+
+Test IDs are designed for enduring RFC semantics, not coexistence among drafts. IDs and corresponding public function names must describe observable test meaning without version markers such as `d18`, `draft-18`, or `moqt18` anywhere in the name.
+
+Retain an ID when a new target changes only section numbers or editorial placement and the test's meaning, observable behavior, applicability, and pass criteria remain equivalent. Retention requires one atomic change that updates the target declarations, exact section references, normative links, message terminology, test vectors, and support manifests as needed.
+
+If an ID's meaning, observable behavior, applicability, or pass criteria become stale or incompatible, retire it. Never reuse a retired ID for different semantics. Introduce a new semantic ID and record the retired ID, its replacement, its last-known target draft, profile revision, implementation source, commit, and image digest in [tests/retired-test-identifiers.json](./tests/retired-test-identifiers.json). Record unavailable legacy provenance explicitly as `unknown`; do not imply that it was captured. A retired ID is a tombstone, not an alias, and test clients must not emit it as a new canonical result.
+
+Historical results record provenance as metadata. Each result set must identify the explicit target draft, profile revision, runner commit, driver commit, and image digest. Consumers must use that metadata rather than infer or parse a draft from an ID.
+
+## Target Migration Checklist
+
+When `implementations.json.current_target` changes, review every canonical test specification and its associated support metadata in the same change. That review includes:
+
+- Protocol References
+- Target-draft declarations
+- Normative links
+- Message terminology
+- Expected outcomes
+- Test vectors
+- Test-client support manifests
+
+For every existing ID, the migration review must state one of these outcomes:
+
+- **Retained**: semantics and pass criteria remain equivalent
+- **Retired/New**: the old ID's last-valid provenance and replacement are recorded, and a new semantic ID is introduced when applicable
+
+Do not treat a mechanical draft-number replacement as sufficient. Automation cannot decide semantic equivalence. The `Identifier Semantics Reviewed For` declaration is a human- or agent-reviewed gate attesting that these retention and retirement decisions were made for the declared target.
+
+## Validation
+
+Each canonical specification must contain exactly one declaration of each form, both matching `implementations.json.current_target`:
+
+```markdown
+**Target Draft**: `draft-18`
+**Identifier Semantics Reviewed For**: `draft-18`
+```
+
+Run `make validate-target-draft`. The validator removes HTML comments and fenced code examples before checking exact declarations, canonical heading and first-column table IDs, external Rust `test_*` function identifiers, formal references, and retirement integrity. Commented or fenced declarations, IDs, functions, and replacement headings are not active. Malformed or decorated definition attempts fail instead of being ignored. The registry has an explicit format version and a stable full-record pin for its initial tombstones. Existing tombstones are immutable and the registry is append-only; `--previous-retired FILE` requires the prior tombstone array to be an exact prefix, and the Make target accepts the same path as `PREVIOUS_RETIRED=FILE`. The validator does not interpret normative target prose or links as public identifiers, and it cannot verify the semantic-equivalence judgment attested by the review declaration. Validator maintainers can run `make test-target-draft-validator` for positive and negative regression cases.
+
+Stacked profiles can include their canonical specs with `make validate-target-draft SPEC_FILES="path/to/profile-spec.md"` or by passing files directly to `scripts/validate-target-draft.sh`.
+
+The existing registration workflow runs when `implementations.json` (including `current_target`), `implementations.schema.json`, or `validate-registration.sh` changes. A registration-wrapper change therefore exercises this validator. The wrapper also passes the prior retirement snapshot for append-only comparison when `--base` contains one. The workflow does not cover spec-only, validator-only, or retirement-registry-only changes. Because its path scope cannot be expanded with the current GitHub App permission, those contributors must run `make validate-target-draft` and `make test-target-draft-validator`; do not assume broader CI coverage.

--- a/docs/TEST-SPECIFICATIONS.md
+++ b/docs/TEST-SPECIFICATIONS.md
@@ -7,6 +7,8 @@ This document has been reorganized into separate, focused documents:
 | **[tests/TEST-CASES.md](./tests/TEST-CASES.md)** | Test case definitions with protocol references |
 | **[TEST-CLIENT-INTERFACE.md](./TEST-CLIENT-INTERFACE.md)** | CLI, environment variables, exit codes, output format |
 | **[IMPLEMENTING-A-TEST-CLIENT.md](./IMPLEMENTING-A-TEST-CLIENT.md)** | Guide for implementing a compatible test client |
+| **[TARGET-DRAFT-POLICY.md](./TARGET-DRAFT-POLICY.md)** | Identifier lifecycle and target-draft review checklist |
+| **[tests/retired-test-identifiers.json](./tests/retired-test-identifiers.json)** | Retired identifier tombstones and replacements |
 
 ## Quick Reference
 
@@ -20,6 +22,8 @@ This document has been reorganized into separate, focused documents:
 | `subscribe-error` | Subscription | Error for non-existent track |
 | `announce-subscribe` | Subscription | Relay routes subscription to publisher |
 | `subscribe-before-announce` | Subscription | Out-of-order subscribe/announce |
+| `publish-without-subscriber` | Track publishing | Exercise the Forward-State-aware lifecycle without a subscriber |
+| `publish-to-pending-subscription` | Track publishing | Rendezvous a subscriber-first request with PUBLISH delivery |
 
 ### Interface Summary
 

--- a/docs/tests/TEST-CASES.md
+++ b/docs/tests/TEST-CASES.md
@@ -205,6 +205,94 @@ Either outcome is valid; the test checks for graceful handling.
 
 ---
 
+## Category: Track Publishing
+
+These tests exercise the **PUBLISH flow**: a publisher sends a `PUBLISH` message directly naming a specific track, and the relay responds with `PUBLISH_OK`. This is distinct from the `PUBLISH_NAMESPACE` + `SUBSCRIBE` flow used in earlier tests, where a publisher announces an entire namespace and the relay routes incoming `SUBSCRIBE` requests back to that publisher. In the PUBLISH flow, the publisher establishes the track directly; the relay matches any arriving `SUBSCRIBE` for that track to the active publisher and routes data accordingly.
+
+### `publish-track-only`
+
+**Protocol References**: MoQT-18 §10.10 (PUBLISH), §10.5 (REQUEST_OK / `PUBLISH_OK` alias)
+
+**Procedure**:
+
+1. Connect to relay and complete SETUP exchange
+2. Send PUBLISH naming the test track (no subscriber is present)
+3. Wait for REQUEST_OK (`PUBLISH_OK`)
+4. Write one subgroup containing a single object into the track
+5. Close the track, signalling end-of-track (PUBLISH_DONE)
+6. Wait for the PUBLISH sequence to complete, then close the connection gracefully
+
+**Test Namespace**: `moq-test/publish`  
+**Test Track**: `published-track`
+
+**Success Criteria**:
+
+- REQUEST_OK (`PUBLISH_OK`) received within timeout
+- Track data written and PUBLISH_DONE sent without error
+- Connection closes cleanly
+
+> **Note**: No subscriber is present; the relay must accept the PUBLISH and the accompanying data without error. Whether the relay buffers or discards data when no subscriber exists is implementation-defined.
+
+**Timeout**: 10 seconds
+
+**mlog Events** (relay-side, suggested):
+
+```json
+{"name":"moqt:control_message_parsed","data":{"message_type":"publish",...}}
+{"name":"moqt:control_message_created","data":{"message_type":"publish_ok",...}}
+{"name":"moqt:data_stream_closed","data":{"type":"subgroup","reason":"publisher_done",...}}
+```
+
+---
+
+### `publish-track-subscribe`
+
+**Protocol References**: MoQT-18 §10.10 (PUBLISH), §10.5 (REQUEST_OK / `PUBLISH_OK` alias), §10.7 (SUBSCRIBE), §10.8 (SUBSCRIBE_OK)
+
+**Topology**: Two concurrent connections (publisher + subscriber)
+
+**Publisher Procedure**:
+
+1. Connect to relay and complete SETUP exchange
+2. Send PUBLISH naming the test track
+3. Wait for REQUEST_OK (`PUBLISH_OK`)
+4. After receiving PUBLISH_OK: write one subgroup containing a single object (allow a brief interval for the subscriber to send its SUBSCRIBE before writing)
+5. Close the track (signal PUBLISH_DONE) once the object has been written
+
+**Subscriber Procedure** (starts after publisher has received PUBLISH_OK):
+
+1. Connect to relay and complete SETUP exchange
+2. Send SUBSCRIBE for the same test namespace and track name as the active PUBLISH
+3. Wait for SUBSCRIBE_OK (the relay must match the SUBSCRIBE to the active PUBLISH publisher)
+4. Receive one subgroup with a single object on the resulting data stream
+5. Verify the received payload matches the expected value
+
+**Test Namespace**: `moq-test/publish`  
+**Test Track**: `published-track`
+
+**Success Criteria**:
+
+- Publisher receives PUBLISH_OK
+- Subscriber receives SUBSCRIBE_OK (relay correctly maps the SUBSCRIBE to the active PUBLISH track)
+- Subscriber receives at least one object with the expected payload
+- Both connections close cleanly
+
+**Timeout**: 10 seconds
+
+**Diagnostic Roles**: `publisher`, `subscriber` — report as `publisher_connection_id` and `subscriber_connection_id` in YAML diagnostics
+
+**mlog Events** (relay-side, suggested):
+
+```json
+{"name":"moqt:control_message_parsed","data":{"message_type":"publish",...}}
+{"name":"moqt:control_message_created","data":{"message_type":"publish_ok",...}}
+{"name":"moqt:control_message_parsed","data":{"message_type":"subscribe",...}}
+{"name":"moqt:control_message_created","data":{"message_type":"subscribe_ok",...}}
+{"name":"moqt:data_stream_opened","data":{"type":"subgroup",...}}
+```
+
+---
+
 ## Future Test Cases
 
 This section outlines potential future test cases. The actual test definitions will be added as implementations mature and working group consensus develops.
@@ -213,30 +301,28 @@ This section outlines potential future test cases. The actual test definitions w
 
 | Identifier | Description | Key Protocol References |
 |------------|-------------|------------------------|
-| `single-object` | Publisher sends 1 object, subscriber receives it | §10 (Data Streams) |
+| `single-object` | Publisher sends 1 object via PUBLISH_NAMESPACE + SUBSCRIBE flow, subscriber receives it | §5.1 (Subscriptions), §10 (Data Streams) |
 | `single-group` | Publisher sends group of N objects | §2.3 (Groups) |
 | `multiple-groups` | Publisher sends 3 groups, subscriber receives all | §2.3 (Groups) |
 | `late-subscriber` | Subscriber joins mid-stream | §5.1 (Subscriptions) |
 
-### Alternative Flow Patterns
+### Message Flow Patterns
 
-Different use cases may require different message flow patterns:
+MoQT supports two primary publisher-subscriber rendezvous patterns, each exercised by separate test categories in this suite:
 
-- **PUBLISH_NAMESPACE + SUBSCRIBE flow**: Publisher announces availability, subscriber requests specific track
-- **SUBSCRIBE_NAMESPACE + PUBLISH flow**: Subscriber expresses interest in namespace prefix, publisher sends tracks
-
-As moq-rs and other implementations add support for both patterns, we should develop test cases that exercise each.
+- **PUBLISH_NAMESPACE + SUBSCRIBE flow** (Category: Subscriptions): Publisher announces namespace availability via `PUBLISH_NAMESPACE`; relay routes incoming `SUBSCRIBE` requests to the publisher. Tests: `announce-only`, `publish-namespace-done`, `announce-subscribe`, `subscribe-before-announce`.
+- **PUBLISH + SUBSCRIBE flow** (Category: Track Publishing): Publisher directly publishes a specific track via `PUBLISH`; the relay matches any incoming `SUBSCRIBE` for that track to the active publisher. Tests: `publish-track-only`, `publish-track-subscribe`.
 
 ### Test Client Capability Matrix
 
 As the test suite grows, different test clients may support different subsets of tests. A capability matrix could help:
 
-| Test Client | `setup-only` | `announce-only` | `publish-namespace-done` | `subscribe-error` | `announce-subscribe` | `subscribe-before-announce` |
-|-------------|--------------|-----------------|--------------------------|-------------------|----------------------|-----------------------------|
-| moq-test-client (moq-rs) | Yes | Yes | Yes | Yes | Yes | Yes |
-| implementation-b | Yes | Yes | No | Yes | No | No |
+| Test Client | `setup-only` | `announce-only` | `publish-namespace-done` | `subscribe-error` | `announce-subscribe` | `subscribe-before-announce` | `publish-track-only` | `publish-track-subscribe` |
+|-------------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| moq-test-client (moq-rs) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| implementation-b | ✓ | ✓ | — | ✓ | — | — | — | — |
 
-The mechanism for declaring and discovering these capabilities is TBD - potentially via a `--list` command that outputs supported test identifiers.
+Test clients declare supported tests via the `--list` command (one identifier per line). The `TESTCASE` environment variable selects a single test; exit code `127` signals an unsupported test.
 
 ---
 

--- a/docs/tests/TEST-CASES.md
+++ b/docs/tests/TEST-CASES.md
@@ -211,25 +211,26 @@ These tests exercise the **PUBLISH flow**: a publisher sends a `PUBLISH` message
 
 ### `publish-track-only`
 
-**Protocol References**: MoQT-18 §10.10 (PUBLISH), §10.5 (REQUEST_OK / `PUBLISH_OK` alias)
+**Protocol References**: MoQT-18 §5.1 (Subscriptions), §9.5 (Publisher Interactions), §10.2.12 (FORWARD), §10.5 (REQUEST_OK / `PUBLISH_OK` alias), §10.10 (PUBLISH), §10.11 (PUBLISH_DONE), §11.4 (Streams)
 
 **Procedure**:
 
 1. Connect to relay and complete SETUP exchange
 2. Send PUBLISH naming the test track (no subscriber is present)
-3. Wait for REQUEST_OK (`PUBLISH_OK`)
-4. Write one subgroup containing a single object into the track
-5. Close the track, signalling end-of-track (PUBLISH_DONE)
-6. Wait for the PUBLISH sequence to complete, then close the connection gracefully
+3. Wait for REQUEST_OK (`PUBLISH_OK`) and record its effective Forward State; an omitted FORWARD parameter means 1
+4. If Forward State is 1, write Group 0, Subgroup 0, Object 0 with payload `moqt18-publish-track-only`, then close the subgroup stream with FIN; if it is 0, send no track data
+5. Close the track with PUBLISH_DONE/TRACK_ENDED and an accurate Stream Count: 1 if a subgroup stream was opened, otherwise 0
+6. Finish the request stream after PUBLISH_DONE and wait for the PUBLISH sequence to complete
 
-**Test Namespace**: `moq-test/publish`  
+**Test Namespace**: `moq-test/publish`
+
 **Test Track**: `published-track`
 
 **Success Criteria**:
 
 - REQUEST_OK (`PUBLISH_OK`) received within timeout
-- Track data written and PUBLISH_DONE sent without error
-- Connection closes cleanly
+- The publisher honors the returned Forward State
+- PUBLISH_DONE/TRACK_ENDED carries the exact Stream Count and is followed by request-stream FIN
 
 > **Note**: No subscriber is present; the relay must accept the PUBLISH and the accompanying data without error. Whether the relay buffers or discards data when no subscriber exists is implementation-defined.
 
@@ -247,35 +248,44 @@ These tests exercise the **PUBLISH flow**: a publisher sends a `PUBLISH` message
 
 ### `publish-track-subscribe`
 
-**Protocol References**: MoQT-18 §10.10 (PUBLISH), §10.5 (REQUEST_OK / `PUBLISH_OK` alias), §10.7 (SUBSCRIBE), §10.8 (SUBSCRIBE_OK)
+**Protocol References**: MoQT-18 §5.1 (Subscriptions), §9.5 (Publisher Interactions), §10.2.6 (RENDEZVOUS_TIMEOUT), §10.2.12 (FORWARD), §10.5 (REQUEST_OK / `PUBLISH_OK` alias), §10.7 (SUBSCRIBE), §10.8 (SUBSCRIBE_OK), §10.10 (PUBLISH), §10.11 (PUBLISH_DONE), §11.4 (Streams)
 
 **Topology**: Two concurrent connections (publisher + subscriber)
+
+**Subscriber Procedure**:
+
+1. Connect to relay and complete SETUP exchange
+2. Send SUBSCRIBE for the test namespace and track with RENDEZVOUS_TIMEOUT set to 5000 ms
+3. After the SUBSCRIBE bytes have been sent, keep the request pending while the publisher connects
 
 **Publisher Procedure**:
 
 1. Connect to relay and complete SETUP exchange
-2. Send PUBLISH naming the test track
-3. Wait for REQUEST_OK (`PUBLISH_OK`)
-4. After receiving PUBLISH_OK: write one subgroup containing a single object (allow a brief interval for the subscriber to send its SUBSCRIBE before writing)
-5. Close the track (signal PUBLISH_DONE) once the object has been written
+2. Send PUBLISH naming the same test track
+3. Wait for REQUEST_OK (`PUBLISH_OK`) with effective Forward State 1; an omitted FORWARD parameter means 1
+4. Require the subscriber to receive SUBSCRIBE_OK
+5. Write Group 0, Subgroup 0, Object 0 with payload `moqt18-publish-track-subscribe`
+6. Close the subgroup stream with FIN
+7. Send PUBLISH_DONE/TRACK_ENDED with Stream Count 1, then finish the request stream
 
-**Subscriber Procedure** (starts after publisher has received PUBLISH_OK):
+**Subscriber Completion**:
 
-1. Connect to relay and complete SETUP exchange
-2. Send SUBSCRIBE for the same test namespace and track name as the active PUBLISH
-3. Wait for SUBSCRIBE_OK (the relay must match the SUBSCRIBE to the active PUBLISH publisher)
-4. Receive one subgroup with a single object on the resulting data stream
-5. Verify the received payload matches the expected value
+1. Receive exactly Group 0, Subgroup 0, Object 0
+2. Verify the exact expected payload
+3. Require PUBLISH_DONE/TRACK_ENDED with Stream Count 1; it may arrive before the subgroup stream, but retain subscription state until the one counted stream closes
 
-**Test Namespace**: `moq-test/publish`  
+**Test Namespace**: `moq-test/publish`
+
 **Test Track**: `published-track`
 
 **Success Criteria**:
 
 - Publisher receives PUBLISH_OK
+- PUBLISH_OK has Forward State 1 before the publisher sends data
 - Subscriber receives SUBSCRIBE_OK (relay correctly maps the SUBSCRIBE to the active PUBLISH track)
-- Subscriber receives at least one object with the expected payload
-- Both connections close cleanly
+- Subscriber receives exactly one object with the expected payload
+- The publisher sends PUBLISH_DONE/TRACK_ENDED with Stream Count 1 only after closing its subgroup stream, then finishes its request stream
+- The subscriber processes exactly one counted subgroup stream and the exact payload even if PUBLISH_DONE arrives first
 
 **Timeout**: 10 seconds
 
@@ -301,7 +311,7 @@ This section outlines potential future test cases. The actual test definitions w
 
 | Identifier | Description | Key Protocol References |
 |------------|-------------|------------------------|
-| `single-object` | Publisher sends 1 object via PUBLISH_NAMESPACE + SUBSCRIBE flow, subscriber receives it | §5.1 (Subscriptions), §10 (Data Streams) |
+| `single-object` | Publisher sends 1 object via PUBLISH_NAMESPACE + SUBSCRIBE flow, subscriber receives it | §5.1 (Subscriptions), §11 (Data Streams and Datagrams) |
 | `single-group` | Publisher sends group of N objects | §2.3 (Groups) |
 | `multiple-groups` | Publisher sends 3 groups, subscriber receives all | §2.3 (Groups) |
 | `late-subscriber` | Subscriber joins mid-stream | §5.1 (Subscriptions) |
@@ -319,10 +329,11 @@ As the test suite grows, different test clients may support different subsets of
 
 | Test Client | `setup-only` | `announce-only` | `publish-namespace-done` | `subscribe-error` | `announce-subscribe` | `subscribe-before-announce` | `publish-track-only` | `publish-track-subscribe` |
 |-------------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| moq-test-client (moq-rs) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| implementation-b | ✓ | ✓ | — | ✓ | — | — | — | — |
+| moq-test-client (moq-rs) | Yes | Name mismatch | Yes | Yes | Name mismatch | Name mismatch | Needs alignment | Needs alignment |
 
-Test clients declare supported tests via the `--list` command (one identifier per line). The `TESTCASE` environment variable selects a single test; exit code `127` signals an unsupported test.
+`moq-test-client` currently lists `publish-namespace-only`, `publish-namespace-subscribe`, and `subscribe-before-publish-namespace` for the three cells marked Name mismatch; the runner does not translate those identifiers. Its two direct-PUBLISH scenarios also require alignment with the procedures above. A listed implementation is a capability claim, not an interoperability result.
+
+Test clients declare available tests via the `--list` command (one identifier per line). The `TESTCASE` environment variable selects a single test; exit code `127` signals an unsupported test.
 
 ---
 
@@ -349,6 +360,6 @@ This approach could enable more sophisticated validation (e.g., verifying relay 
 
 ## References
 
-- [draft-ietf-moq-transport-14](https://www.ietf.org/archive/id/draft-ietf-moq-transport-14.html) - MoQT Protocol Specification
+- [draft-ietf-moq-transport-18](https://www.ietf.org/archive/id/draft-ietf-moq-transport-18.html) - MoQT Protocol Specification
 - [RFC 2026 §4](https://www.rfc-editor.org/rfc/rfc2026#section-4) - IETF interoperability testing requirements
 - [QUIC Interop Runner](https://github.com/quic-interop/quic-interop-runner) - Inspiration for this framework

--- a/docs/tests/TEST-CASES.md
+++ b/docs/tests/TEST-CASES.md
@@ -4,6 +4,9 @@
 
 This document defines interoperability test cases for Media over QUIC Transport (MoQT). These specifications are designed to be implementation-neutral and precise enough that any MoQT implementation can build a compatible test client.
 
+**Target Draft**: `draft-18`
+**Identifier Semantics Reviewed For**: `draft-18`
+
 **Protocol Reference**: [draft-ietf-moq-transport-18](https://www.ietf.org/archive/id/draft-ietf-moq-transport-18.html)
 
 > **Note**: Section references (e.g., "MoQT-18 §10.3") refer to the draft version above. Message names use the current draft-18 terminology. Where the draft defines request-specific aliases such as `PUBLISH_NAMESPACE_OK`, those aliases refer to a `REQUEST_OK` response.
@@ -209,7 +212,7 @@ Either outcome is valid; the test checks for graceful handling.
 
 These tests exercise the **PUBLISH flow**: a publisher sends a `PUBLISH` message directly naming a specific track, and the relay responds with `PUBLISH_OK`. This is distinct from the `PUBLISH_NAMESPACE` + `SUBSCRIBE` flow used in earlier tests, where a publisher announces an entire namespace and the relay routes incoming `SUBSCRIBE` requests back to that publisher. In the PUBLISH flow, the publisher establishes the track directly; the relay matches any arriving `SUBSCRIBE` for that track to the active publisher and routes data accordingly.
 
-### `publish-track-only`
+### `publish-without-subscriber`
 
 **Protocol References**: MoQT-18 §5.1 (Subscriptions), §9.5 (Publisher Interactions), §10.2.12 (FORWARD), §10.5 (REQUEST_OK / `PUBLISH_OK` alias), §10.10 (PUBLISH), §10.11 (PUBLISH_DONE), §11.4 (Streams)
 
@@ -218,7 +221,7 @@ These tests exercise the **PUBLISH flow**: a publisher sends a `PUBLISH` message
 1. Connect to relay and complete SETUP exchange
 2. Send PUBLISH naming the test track (no subscriber is present)
 3. Wait for REQUEST_OK (`PUBLISH_OK`) and record its effective Forward State; an omitted FORWARD parameter means 1
-4. If Forward State is 1, write Group 0, Subgroup 0, Object 0 with payload `moqt18-publish-track-only`, then close the subgroup stream with FIN; if it is 0, send no track data
+4. If Forward State is 1, write Group 0, Subgroup 0, Object 0 with payload `publish-without-subscriber`, then close the subgroup stream with FIN; if it is 0, send no track data
 5. Close the track with PUBLISH_DONE/TRACK_ENDED and an accurate Stream Count: 1 if a subgroup stream was opened, otherwise 0
 6. Finish the request stream after PUBLISH_DONE and wait for the PUBLISH sequence to complete
 
@@ -246,7 +249,7 @@ These tests exercise the **PUBLISH flow**: a publisher sends a `PUBLISH` message
 
 ---
 
-### `publish-track-subscribe`
+### `publish-to-pending-subscription`
 
 **Protocol References**: MoQT-18 §5.1 (Subscriptions), §9.5 (Publisher Interactions), §10.2.6 (RENDEZVOUS_TIMEOUT), §10.2.12 (FORWARD), §10.5 (REQUEST_OK / `PUBLISH_OK` alias), §10.7 (SUBSCRIBE), §10.8 (SUBSCRIBE_OK), §10.10 (PUBLISH), §10.11 (PUBLISH_DONE), §11.4 (Streams)
 
@@ -264,7 +267,7 @@ These tests exercise the **PUBLISH flow**: a publisher sends a `PUBLISH` message
 2. Send PUBLISH naming the same test track
 3. Wait for REQUEST_OK (`PUBLISH_OK`) with effective Forward State 1; an omitted FORWARD parameter means 1
 4. Require the subscriber to receive SUBSCRIBE_OK
-5. Write Group 0, Subgroup 0, Object 0 with payload `moqt18-publish-track-subscribe`
+5. Write Group 0, Subgroup 0, Object 0 with payload `publish-to-pending-subscription`
 6. Close the subgroup stream with FIN
 7. Send PUBLISH_DONE/TRACK_ENDED with Stream Count 1, then finish the request stream
 
@@ -321,19 +324,11 @@ This section outlines potential future test cases. The actual test definitions w
 MoQT supports two primary publisher-subscriber rendezvous patterns, each exercised by separate test categories in this suite:
 
 - **PUBLISH_NAMESPACE + SUBSCRIBE flow** (Category: Subscriptions): Publisher announces namespace availability via `PUBLISH_NAMESPACE`; relay routes incoming `SUBSCRIBE` requests to the publisher. Tests: `announce-only`, `publish-namespace-done`, `announce-subscribe`, `subscribe-before-announce`.
-- **PUBLISH + SUBSCRIBE flow** (Category: Track Publishing): Publisher directly publishes a specific track via `PUBLISH`; the relay matches any incoming `SUBSCRIBE` for that track to the active publisher. Tests: `publish-track-only`, `publish-track-subscribe`.
+- **PUBLISH + SUBSCRIBE flow** (Category: Track Publishing): Publisher directly publishes a specific track via `PUBLISH`; the relay matches any incoming `SUBSCRIBE` for that track to the active publisher. Tests: `publish-without-subscriber`, `publish-to-pending-subscription`.
 
-### Test Client Capability Matrix
+### Test Client Support
 
-As the test suite grows, different test clients may support different subsets of tests. A capability matrix could help:
-
-| Test Client | `setup-only` | `announce-only` | `publish-namespace-done` | `subscribe-error` | `announce-subscribe` | `subscribe-before-announce` | `publish-track-only` | `publish-track-subscribe` |
-|-------------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| moq-test-client (moq-rs) | Yes | Name mismatch | Yes | Yes | Name mismatch | Name mismatch | Needs alignment | Needs alignment |
-
-`moq-test-client` currently lists `publish-namespace-only`, `publish-namespace-subscribe`, and `subscribe-before-publish-namespace` for the three cells marked Name mismatch; the runner does not translate those identifiers. Its two direct-PUBLISH scenarios also require alignment with the procedures above. A listed implementation is a capability claim, not an interoperability result.
-
-Test clients declare available tests via the `--list` command (one identifier per line). The `TESTCASE` environment variable selects a single test; exit code `127` signals an unsupported test.
+This specification does not maintain a prose capability matrix. Evolving support claims belong in machine-readable conformance profiles with pinned implementation provenance and evidence. Run-specific observations belong in result artifacts. Test clients still declare available tests through `--list`; `TESTCASE` selects one test and exit code `127` signals an unsupported test.
 
 ---
 

--- a/docs/tests/TEST-CASES.md
+++ b/docs/tests/TEST-CASES.md
@@ -212,6 +212,13 @@ Either outcome is valid; the test checks for graceful handling.
 
 These tests exercise the **PUBLISH flow**: a publisher sends a `PUBLISH` message directly naming a specific track, and the relay responds with `PUBLISH_OK`. This is distinct from the `PUBLISH_NAMESPACE` + `SUBSCRIBE` flow used in earlier tests, where a publisher announces an entire namespace and the relay routes incoming `SUBSCRIBE` requests back to that publisher. In the PUBLISH flow, the publisher establishes the track directly; the relay matches any arriving `SUBSCRIBE` for that track to the active publisher and routes data accordingly.
 
+Each run generates a fresh 128-bit Run ID encoded as 32 lowercase hexadecimal characters. The Full Track Name is unique to the run:
+
+- Track Namespace: `("moq-interop", <test-id>, <run-id>)`
+- Track Name: `test`
+
+Publisher and subscriber roles use the same Full Track Name and report the Run ID in diagnostics. A fixed track name must not be reused across runs because stale state or a concurrent run could satisfy the test.
+
 The two tests below are new runner-owned semantic specifications. Their presence does not claim that any implementation currently exposes or passes them.
 
 ### `publish-without-subscriber`
@@ -227,9 +234,7 @@ The two tests below are new runner-owned semantic specifications. Their presence
 5. Close the track with PUBLISH_DONE/TRACK_ENDED and an accurate Stream Count: 1 if a subgroup stream was opened, otherwise 0
 6. Finish the request stream after PUBLISH_DONE and wait for the PUBLISH sequence to complete
 
-**Test Namespace**: `moq-test/publish`
-
-**Test Track**: `published-track`
+**Test ID**: `publish-without-subscriber`
 
 **Success Criteria**:
 
@@ -279,9 +284,7 @@ The two tests below are new runner-owned semantic specifications. Their presence
 2. Verify the exact expected payload
 3. Require PUBLISH_DONE/TRACK_ENDED with Stream Count 1; it may arrive before the subgroup stream, but retain subscription state until the one counted stream closes
 
-**Test Namespace**: `moq-test/publish`
-
-**Test Track**: `published-track`
+**Test ID**: `publish-to-pending-subscription`
 
 **Success Criteria**:
 

--- a/docs/tests/TEST-CASES.md
+++ b/docs/tests/TEST-CASES.md
@@ -212,6 +212,8 @@ Either outcome is valid; the test checks for graceful handling.
 
 These tests exercise the **PUBLISH flow**: a publisher sends a `PUBLISH` message directly naming a specific track, and the relay responds with `PUBLISH_OK`. This is distinct from the `PUBLISH_NAMESPACE` + `SUBSCRIBE` flow used in earlier tests, where a publisher announces an entire namespace and the relay routes incoming `SUBSCRIBE` requests back to that publisher. In the PUBLISH flow, the publisher establishes the track directly; the relay matches any arriving `SUBSCRIBE` for that track to the active publisher and routes data accordingly.
 
+The two tests below are new runner-owned semantic specifications. Their presence does not claim that any implementation currently exposes or passes them.
+
 ### `publish-without-subscriber`
 
 **Protocol References**: MoQT-18 §5.1 (Subscriptions), §9.5 (Publisher Interactions), §10.2.12 (FORWARD), §10.5 (REQUEST_OK / `PUBLISH_OK` alias), §10.10 (PUBLISH), §10.11 (PUBLISH_DONE), §11.4 (Streams)

--- a/docs/tests/retired-test-identifiers.json
+++ b/docs/tests/retired-test-identifiers.json
@@ -1,31 +1,5 @@
 {
   "format": "moqt-retired-test-identifiers",
   "format_version": 1,
-  "initial_tombstone_pin": "v1:publish-track-only>publish-without-subscriber;publish-track-subscribe>publish-to-pending-subscription",
-  "retired_identifiers": [
-    {
-      "id": "publish-track-only",
-      "last_known_target": "draft-18",
-      "last_known_profile_revision": "legacy-unversioned",
-      "last_known_implementation": {
-        "repository": "https://github.com/cloudflare/moq-rs",
-        "commit": "b01d3f6707e3a74f69905722b451a08cbb3364f3",
-        "image_digest": "unknown"
-      },
-      "reason": "The legacy client/result scenario does not enforce the canonical Forward-State-aware object and PUBLISH_DONE lifecycle, including exact Stream Count and request-stream completion.",
-      "replacement": "publish-without-subscriber"
-    },
-    {
-      "id": "publish-track-subscribe",
-      "last_known_target": "draft-18",
-      "last_known_profile_revision": "legacy-unversioned",
-      "last_known_implementation": {
-        "repository": "https://github.com/cloudflare/moq-rs",
-        "commit": "b01d3f6707e3a74f69905722b451a08cbb3364f3",
-        "image_digest": "unknown"
-      },
-      "reason": "The legacy client/result scenario does not enforce subscriber-first rendezvous, Forward State 1, exact object delivery, and counted-stream completion required by the canonical test.",
-      "replacement": "publish-to-pending-subscription"
-    }
-  ]
+  "retired_identifiers": []
 }

--- a/docs/tests/retired-test-identifiers.json
+++ b/docs/tests/retired-test-identifiers.json
@@ -1,0 +1,31 @@
+{
+  "format": "moqt-retired-test-identifiers",
+  "format_version": 1,
+  "initial_tombstone_pin": "v1:publish-track-only>publish-without-subscriber;publish-track-subscribe>publish-to-pending-subscription",
+  "retired_identifiers": [
+    {
+      "id": "publish-track-only",
+      "last_known_target": "draft-18",
+      "last_known_profile_revision": "legacy-unversioned",
+      "last_known_implementation": {
+        "repository": "https://github.com/cloudflare/moq-rs",
+        "commit": "b01d3f6707e3a74f69905722b451a08cbb3364f3",
+        "image_digest": "unknown"
+      },
+      "reason": "The legacy client/result scenario does not enforce the canonical Forward-State-aware object and PUBLISH_DONE lifecycle, including exact Stream Count and request-stream completion.",
+      "replacement": "publish-without-subscriber"
+    },
+    {
+      "id": "publish-track-subscribe",
+      "last_known_target": "draft-18",
+      "last_known_profile_revision": "legacy-unversioned",
+      "last_known_implementation": {
+        "repository": "https://github.com/cloudflare/moq-rs",
+        "commit": "b01d3f6707e3a74f69905722b451a08cbb3364f3",
+        "image_digest": "unknown"
+      },
+      "reason": "The legacy client/result scenario does not enforce subscriber-first rendezvous, Forward State 1, exact object delivery, and counted-stream completion required by the canonical test.",
+      "replacement": "publish-to-pending-subscription"
+    }
+  ]
+}

--- a/implementations.json
+++ b/implementations.json
@@ -302,7 +302,7 @@
       "organization": "Cloudflare",
       "repository": "https://github.com/cloudflare/moq-rs",
       "draft_versions": ["draft-18"],
-      "notes": "Rust implementation. Deployed as a single instance relay for interop testing, tracking the draft-18-dev branch.",
+      "notes": "Rust implementation. Deployed as a single instance relay for interop testing, tracking the draft-18-dev branch. Test client (moq-test-client) implements all current test cases including the data plane tests `publish-track-only` and `publish-track-subscribe`.",
       "roles": {
         "relay": {
           "docker": {

--- a/implementations.json
+++ b/implementations.json
@@ -290,7 +290,7 @@
       "organization": "Cloudflare",
       "repository": "https://github.com/cloudflare/moq-rs",
       "draft_versions": ["draft-18"],
-      "notes": "Rust implementation. Deployed as a single instance relay for interop testing, tracking the draft-18-dev branch. Test client (moq-test-client) implements all current test cases including the data plane tests `publish-track-only` and `publish-track-subscribe`.",
+      "notes": "Rust implementation. Deployed as a single instance relay for interop testing, tracking the draft-18-dev branch. The tracked source contains `publish-track-only` and `publish-track-subscribe` scenarios that still need alignment with the canonical procedures; the mutable client image has not been independently verified for those cases.",
       "roles": {
         "relay": {
           "docker": {

--- a/implementations.json
+++ b/implementations.json
@@ -290,7 +290,7 @@
       "organization": "Cloudflare",
       "repository": "https://github.com/cloudflare/moq-rs",
       "draft_versions": ["draft-18"],
-      "notes": "Rust implementation. Deployed as a single instance relay for interop testing, tracking the draft-18-dev branch. The tracked source contains `publish-track-only` and `publish-track-subscribe` scenarios that still need alignment with the canonical procedures; the mutable client image has not been independently verified for those cases.",
+      "notes": "Rust implementation. Deployed as a single instance relay for interop testing, tracking the draft-18-dev branch.",
       "roles": {
         "relay": {
           "docker": {

--- a/scripts/test-validate-target-draft.sh
+++ b/scripts/test-validate-target-draft.sh
@@ -11,6 +11,7 @@ PRIMARY_SPEC="$FIXTURE_DIR/TEST-CASES.md"
 OPTIONAL_SPEC="$FIXTURE_DIR/PROFILE-TESTS.md"
 RETIRED_FILE="$FIXTURE_DIR/retired-test-identifiers.json"
 PREVIOUS_RETIRED_FILE="$FIXTURE_DIR/previous-retired-test-identifiers.json"
+PREVIOUS_SPEC_FILE="$FIXTURE_DIR/previous-test-cases.md"
 TESTS=0
 
 trap 'rm -rf "$FIXTURE_DIR"' EXIT
@@ -42,12 +43,8 @@ write_valid_spec() {
         '| stable-table-test | Active test |' \
         '| `backticked-table-test` | Active test |' \
         '' \
-        'The driver exposes `test_semantic_api ()`.' \
-        'fn test_semantic_rust_api   () {}' \
-        '' \
-        '```rust' \
-        '#[test]' \
-        'fn test_DRAFT_99_ignored () {}' \
+        '```markdown' \
+        '### fenced-DRAFT_99-ignored' \
         '```' > "$PRIMARY_SPEC"
 }
 
@@ -59,7 +56,7 @@ reset_fixtures() {
     write_config
     write_valid_spec
     write_valid_registry
-    rm -f "$OPTIONAL_SPEC" "$PREVIOUS_RETIRED_FILE"
+    rm -f "$OPTIONAL_SPEC" "$PREVIOUS_RETIRED_FILE" "$PREVIOUS_SPEC_FILE"
 }
 
 rewrite_registry() {
@@ -80,14 +77,9 @@ append_retirement() {
         '.retired_identifiers += [{
             id: $id,
             last_known_target: "draft-18",
-            last_known_profile_revision: "legacy-unversioned",
-            last_known_implementation: {
-                repository: "https://github.com/cloudflare/moq-rs",
-                commit: "b01d3f6707e3a74f69905722b451a08cbb3364f3",
-                image_digest: "unknown"
-            },
-            reason: "Legacy behavior differs.",
-            replacement: $replacement
+            last_known_profile_revision: "synthetic-profile-v1",
+            reason: "Synthetic canonical behavior changed.",
+            replacement: (if $replacement == "__NULL__" then null else $replacement end)
         }]' \
         "$registry" > "$FIXTURE_DIR/appended-registry.json"
     mv "$FIXTURE_DIR/appended-registry.json" "$registry"
@@ -95,12 +87,13 @@ append_retirement() {
 
 append_identifier_table_row() {
     local first_cell="$1"
+    local destination="${2:-$PRIMARY_SPEC}"
 
     printf '%s\n' \
         '' \
         '| Identifier | Description |' \
         '|------------|-------------|' \
-        "| $first_cell | Active test |" >> "$PRIMARY_SPEC"
+        "| $first_cell | Active test |" >> "$destination"
 }
 
 run_validator() {
@@ -140,7 +133,7 @@ expect_fail() {
 }
 
 reset_fixtures
-expect_pass "valid exact declarations, plain/backticked IDs, and external test functions" run_validator
+expect_pass "valid exact declarations and plain/backticked heading IDs" run_validator
 
 reset_fixtures
 printf '%s\n' 'Ordinary prose about the Target Draft does not declare it again.' >> "$PRIMARY_SPEC"
@@ -170,9 +163,8 @@ printf '%s\n' \
     '**Target Draft**: `draft-17`' \
     '**Identifier Semantics Reviewed For**: `draft-17`' \
     '### publish-without-subscriber' \
-    'fn test_moqt_17_ignored () {}' \
     '```' >> "$PRIMARY_SPEC"
-expect_pass "fenced declarations, IDs, and functions are ignored" run_validator
+expect_pass "fenced declarations and IDs are ignored" run_validator
 
 reset_fixtures
 printf '%s\n' \
@@ -217,8 +209,17 @@ printf '%s\n' '### decorated-test (extra)' >> "$PRIMARY_SPEC"
 expect_fail "decorated plain heading attempt" "malformed canonical test heading" run_validator
 
 reset_fixtures
+printf '%s\n' ' ### indent-one' '  ### indent-two' '   ### indent-three' >> "$PRIMARY_SPEC"
+expect_pass "Markdown headings accept one to three leading spaces" run_validator
+
+reset_fixtures
+append_retirement "$RETIRED_FILE" "retired-indented-id" "four-space-heading"
+printf '%s\n' '    ### four-space-heading' >> "$PRIMARY_SPEC"
+expect_fail "four-space heading is not an active definition" "does not terminate at an active canonical ID" run_validator
+
+reset_fixtures
 append_identifier_table_row '`decorated-table-test` extra'
-expect_fail "decorated first-column table attempt" "malformed canonical first-column table ID" run_validator
+expect_pass "decorated table proposal is not an active definition" run_validator
 
 reset_fixtures
 printf '%s\n' '### `case-d18-middle`' >> "$PRIMARY_SPEC"
@@ -230,19 +231,19 @@ expect_fail "draft-NN token anywhere" "version-specific public heading ID" run_v
 
 reset_fixtures
 append_identifier_table_row 'case-DRAFT_18-middle'
-expect_fail "case-insensitive draft_NN token anywhere" "version-specific public first-column table ID" run_validator
+expect_fail "case-insensitive draft_NN table hygiene" "version-specific public test-ID table entry" run_validator
 
 reset_fixtures
 append_identifier_table_row '`case-moqt18-middle`'
-expect_fail "moqtNN token anywhere" "version-specific public first-column table ID" run_validator
+expect_fail "moqtNN table hygiene" "version-specific public test-ID table entry" run_validator
 
 reset_fixtures
-printf '%s\n' 'The API is `test_case_MoQt-18_middle (`.' >> "$PRIMARY_SPEC"
-expect_fail "case-insensitive moqt-NN function token" "version-specific public function 'test_case_MoQt-18_middle'" run_validator
+append_identifier_table_row 'case-MOQT-18-middle'
+expect_fail "case-insensitive moqt-NN table hygiene" "version-specific public test-ID table entry" run_validator
 
 reset_fixtures
-printf '%s\n' 'fn test_case_moqt_18_middle   () {}' >> "$PRIMARY_SPEC"
-expect_fail "moqt_NN Rust function with whitespace" "version-specific public function 'test_case_moqt_18_middle'" run_validator
+append_identifier_table_row 'case-moqt_18-middle'
+expect_fail "moqt_NN table hygiene" "version-specific public test-ID table entry" run_validator
 
 reset_fixtures
 printf '%s\n' 'Protocol References: MoQT-17 and draft-ietf-moq-transport-17' >> "$PRIMARY_SPEC"
@@ -255,47 +256,119 @@ expect_fail "duplicate active heading ID" "duplicate active canonical ID 'duplic
 reset_fixtures
 printf '%s\n' '### duplicate-cross-surface' >> "$PRIMARY_SPEC"
 append_identifier_table_row 'duplicate-cross-surface'
-expect_fail "duplicate active ID across heading and table" "duplicate active canonical ID 'duplicate-cross-surface'" run_validator
+expect_pass "table proposal does not duplicate active heading" run_validator
 
 reset_fixtures
-printf '%s\n' '### publish-track-only' >> "$PRIMARY_SPEC"
-expect_fail "retired ID reused as active" "retired ID 'publish-track-only' is reused as an active canonical ID" run_validator
+append_retirement "$RETIRED_FILE" "retired-synthetic-id" "publish-without-subscriber"
+printf '%s\n' '### retired-synthetic-id' >> "$PRIMARY_SPEC"
+expect_fail "retired ID reused as active" "retired ID 'retired-synthetic-id' is reused as an active canonical ID" run_validator
 
 reset_fixtures
+append_retirement "$RETIRED_FILE" "retired-synthetic-id" "fenced-replacement-id"
 printf '%s\n' \
     '# Canonical Tests' \
     '**Target Draft**: `draft-18`' \
     '**Identifier Semantics Reviewed For**: `draft-18`' \
+    '### publish-without-subscriber' \
     '### publish-to-pending-subscription' \
     '```markdown' \
-    '### publish-without-subscriber' \
+    '### fenced-replacement-id' \
     '```' > "$PRIMARY_SPEC"
-expect_fail "fenced replacement heading is not active" "replacement 'publish-without-subscriber'" run_validator
+expect_fail "fenced replacement heading is not active" "does not terminate at an active canonical ID" run_validator
 
 reset_fixtures
-rewrite_registry '(.retired_identifiers[] | select(.id == "publish-track-only")).replacement = "publish-track-only"'
-expect_fail "replacement differs from retired ID" "retired ID 'publish-track-only' must have a different replacement" run_validator
+append_retirement "$RETIRED_FILE" "retired-synthetic-id" "retired-synthetic-id"
+expect_fail "self replacement is a cycle" "contains a cycle at 'retired-synthetic-id'" run_validator
 
 reset_fixtures
-rewrite_registry '(.retired_identifiers[] | select(.id == "publish-track-only")).replacement = "missing-replacement"'
-expect_fail "replacement exists as active heading" "replacement 'missing-replacement' for retired ID 'publish-track-only' is not an active canonical heading ID" run_validator
+append_retirement "$RETIRED_FILE" "retired-synthetic-id" "missing-replacement"
+expect_fail "replacement chain must reach active heading" "does not terminate at an active canonical ID" run_validator
 
 reset_fixtures
-rewrite_registry '.retired_identifiers += [.retired_identifiers[0]]'
-expect_fail "retired IDs are unique" "contains duplicate retired ID 'publish-track-only'" run_validator
+append_retirement "$RETIRED_FILE" "retired-null-id" "__NULL__"
+expect_pass "explicit null replacement is allowed" run_validator
 
 reset_fixtures
-rewrite_registry '.retired_identifiers |= map(select(.id != "publish-track-only"))'
-printf '%s\n' '### publish-track-only' >> "$PRIMARY_SPEC"
-expect_fail "deleted pinned tombstone cannot enable ID reuse" "pinned retired ID 'publish-track-only' is reused as an active canonical ID" run_validator
+append_retirement "$RETIRED_FILE" "retired-chain-a" "retired-chain-b"
+append_retirement "$RETIRED_FILE" "retired-chain-b" "chain-active-id"
+printf '%s\n' '### chain-active-id' >> "$PRIMARY_SPEC"
+expect_pass "retirement chain terminates at active heading" run_validator
 
 reset_fixtures
-rewrite_registry '(.retired_identifiers[0].reason) = "Changed reason"'
-expect_fail "initial tombstone reason is pinned" "does not match the pinned initial tombstones" run_validator
+append_retirement "$RETIRED_FILE" "retired-cycle-a" "retired-cycle-b"
+append_retirement "$RETIRED_FILE" "retired-cycle-b" "retired-cycle-a"
+expect_fail "retirement chain cycle is rejected" "contains a cycle" run_validator
 
 reset_fixtures
-rewrite_registry '(.retired_identifiers[0].last_known_implementation.commit) = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"'
-expect_fail "initial tombstone provenance is pinned" "does not match the pinned initial tombstones" run_validator
+append_retirement "$RETIRED_FILE" "retired-chain-a" "retired-chain-b"
+append_retirement "$RETIRED_FILE" "retired-chain-b" "__NULL__"
+expect_fail "non-null chain cannot terminate at null retirement" "terminates at retired ID 'retired-chain-b' with no replacement" run_validator
+
+reset_fixtures
+append_retirement "$RETIRED_FILE" "retired-table-id" "table-only-replacement"
+append_identifier_table_row 'table-only-replacement'
+expect_fail "table proposal cannot satisfy retirement replacement" "does not terminate at an active canonical ID" run_validator
+
+reset_fixtures
+append_retirement "$RETIRED_FILE" "retired-profile-id" "profile-only-replacement"
+printf '%s\n' \
+    '# Optional Profile' \
+    '**Target Draft**: `draft-18`' \
+    '**Identifier Semantics Reviewed For**: `draft-18`' \
+    '### profile-only-replacement' > "$OPTIONAL_SPEC"
+expect_fail "additional profile cannot satisfy primary retirement" "does not terminate at an active canonical ID" run_validator "$OPTIONAL_SPEC"
+
+reset_fixtures
+rewrite_registry '.unexpected = true'
+expect_fail "registry rejects extra top-level keys" "invalid registry format or retirement record" run_validator
+
+reset_fixtures
+append_retirement "$RETIRED_FILE" "retired-extra-field" "publish-without-subscriber"
+rewrite_registry '.retired_identifiers[0].unexpected = true'
+expect_fail "registry rejects extra retirement keys" "invalid registry format or retirement record" run_validator
+
+reset_fixtures
+append_retirement "$RETIRED_FILE" "retired-synthetic-id" "publish-without-subscriber"
+append_retirement "$RETIRED_FILE" "retired-synthetic-id" "publish-without-subscriber"
+expect_fail "retired IDs are unique" "contains duplicate retired ID 'retired-synthetic-id'" run_validator
+
+reset_fixtures
+cp "$RETIRED_FILE" "$PREVIOUS_RETIRED_FILE"
+append_retirement "$PREVIOUS_RETIRED_FILE" "retired-synthetic-id" "publish-without-subscriber"
+printf '%s\n' '### retired-synthetic-id' >> "$PRIMARY_SPEC"
+expect_fail "deleted tombstone cannot enable ID reuse" "previous tombstone array is not an exact prefix" run_validator --previous-retired "$PREVIOUS_RETIRED_FILE"
+
+reset_fixtures
+cp "$PRIMARY_SPEC" "$PREVIOUS_SPEC_FILE"
+expect_pass "unchanged previous canonical IDs remain active" run_validator --previous-spec "$PREVIOUS_SPEC_FILE"
+
+reset_fixtures
+cp "$PRIMARY_SPEC" "$PREVIOUS_SPEC_FILE"
+printf '%s\n' '### deleted-without-tombstone' >> "$PREVIOUS_SPEC_FILE"
+expect_fail "deleted active ID requires tombstone" "previous canonical ID 'deleted-without-tombstone' is missing without a retirement tombstone" run_validator --previous-spec "$PREVIOUS_SPEC_FILE"
+
+reset_fixtures
+cp "$PRIMARY_SPEC" "$PREVIOUS_SPEC_FILE"
+append_identifier_table_row 'deleted-table-id' "$PREVIOUS_SPEC_FILE"
+expect_pass "previous table proposal is not an active ID" run_validator --previous-spec "$PREVIOUS_SPEC_FILE"
+
+reset_fixtures
+cp "$PRIMARY_SPEC" "$PREVIOUS_SPEC_FILE"
+printf '%s\n' '### renamed-old-id' >> "$PREVIOUS_SPEC_FILE"
+printf '%s\n' '### renamed-new-id' >> "$PRIMARY_SPEC"
+expect_fail "renamed active ID requires tombstone" "previous canonical ID 'renamed-old-id' is missing without a retirement tombstone" run_validator --previous-spec "$PREVIOUS_SPEC_FILE"
+
+reset_fixtures
+cp "$PRIMARY_SPEC" "$PREVIOUS_SPEC_FILE"
+printf '%s\n' '### retired-old-id' >> "$PREVIOUS_SPEC_FILE"
+printf '%s\n' '### retired-new-id' >> "$PRIMARY_SPEC"
+append_retirement "$RETIRED_FILE" "retired-old-id" "retired-new-id"
+expect_pass "valid active ID retirement and replacement" run_validator --previous-spec "$PREVIOUS_SPEC_FILE"
+
+reset_fixtures
+cp "$PRIMARY_SPEC" "$PREVIOUS_SPEC_FILE"
+printf '%s\n' '<!-- ### hidden-previous-id -->' '```markdown' '### fenced-previous-id' '```' >> "$PREVIOUS_SPEC_FILE"
+expect_pass "hidden previous IDs do not require tombstones" run_validator --previous-spec "$PREVIOUS_SPEC_FILE"
 
 reset_fixtures
 cp "$RETIRED_FILE" "$PREVIOUS_RETIRED_FILE"
@@ -316,9 +389,5 @@ cp "$RETIRED_FILE" "$PREVIOUS_RETIRED_FILE"
 append_retirement "$RETIRED_FILE" "legacy-extra" "replacement-extra"
 printf '%s\n' '### replacement-extra' >> "$PRIMARY_SPEC"
 expect_pass "append-only retirement addition" run_validator --previous-retired "$PREVIOUS_RETIRED_FILE"
-
-reset_fixtures
-rewrite_registry '.initial_tombstone_pin = "changed"'
-expect_fail "initial tombstone pin is stable" "does not match the pinned initial tombstones" run_validator
 
 echo "1..$TESTS"

--- a/scripts/test-validate-target-draft.sh
+++ b/scripts/test-validate-target-draft.sh
@@ -1,0 +1,324 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+VALIDATOR="$SCRIPT_DIR/validate-target-draft.sh"
+FIXTURE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/test-target-draft.XXXXXX")"
+CONFIG_FILE="$FIXTURE_DIR/implementations.json"
+PRIMARY_SPEC="$FIXTURE_DIR/TEST-CASES.md"
+OPTIONAL_SPEC="$FIXTURE_DIR/PROFILE-TESTS.md"
+RETIRED_FILE="$FIXTURE_DIR/retired-test-identifiers.json"
+PREVIOUS_RETIRED_FILE="$FIXTURE_DIR/previous-retired-test-identifiers.json"
+TESTS=0
+
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+write_config() {
+    printf '%s\n' \
+        '{' \
+        '  "current_target": "draft-18"' \
+        '}' > "$CONFIG_FILE"
+}
+
+write_valid_spec() {
+    printf '%s\n' \
+        '# Canonical Tests' \
+        '' \
+        '**Target Draft**: `draft-18`' \
+        '**Identifier Semantics Reviewed For**: `draft-18`' \
+        '' \
+        '## MoQT-18 Normative Target Text' \
+        '' \
+        'See [draft-ietf-moq-transport-18](https://www.ietf.org/archive/id/draft-ietf-moq-transport-18.html).' \
+        '' \
+        '### `publish-without-subscriber`' \
+        '' \
+        '### publish-to-pending-subscription' \
+        '' \
+        '| Identifier | Description |' \
+        '|------------|-------------|' \
+        '| stable-table-test | Active test |' \
+        '| `backticked-table-test` | Active test |' \
+        '' \
+        'The driver exposes `test_semantic_api ()`.' \
+        'fn test_semantic_rust_api   () {}' \
+        '' \
+        '```rust' \
+        '#[test]' \
+        'fn test_DRAFT_99_ignored () {}' \
+        '```' > "$PRIMARY_SPEC"
+}
+
+write_valid_registry() {
+    cp "$ROOT_DIR/docs/tests/retired-test-identifiers.json" "$RETIRED_FILE"
+}
+
+reset_fixtures() {
+    write_config
+    write_valid_spec
+    write_valid_registry
+    rm -f "$OPTIONAL_SPEC" "$PREVIOUS_RETIRED_FILE"
+}
+
+rewrite_registry() {
+    local filter="$1"
+
+    jq "$filter" "$RETIRED_FILE" > "$FIXTURE_DIR/rewritten-registry.json"
+    mv "$FIXTURE_DIR/rewritten-registry.json" "$RETIRED_FILE"
+}
+
+append_retirement() {
+    local registry="$1"
+    local retired_id="$2"
+    local replacement="$3"
+
+    jq \
+        --arg id "$retired_id" \
+        --arg replacement "$replacement" \
+        '.retired_identifiers += [{
+            id: $id,
+            last_known_target: "draft-18",
+            last_known_profile_revision: "legacy-unversioned",
+            last_known_implementation: {
+                repository: "https://github.com/cloudflare/moq-rs",
+                commit: "b01d3f6707e3a74f69905722b451a08cbb3364f3",
+                image_digest: "unknown"
+            },
+            reason: "Legacy behavior differs.",
+            replacement: $replacement
+        }]' \
+        "$registry" > "$FIXTURE_DIR/appended-registry.json"
+    mv "$FIXTURE_DIR/appended-registry.json" "$registry"
+}
+
+append_identifier_table_row() {
+    local first_cell="$1"
+
+    printf '%s\n' \
+        '' \
+        '| Identifier | Description |' \
+        '|------------|-------------|' \
+        "| $first_cell | Active test |" >> "$PRIMARY_SPEC"
+}
+
+run_validator() {
+    TARGET_DRAFT_CONFIG_FILE="$CONFIG_FILE" \
+    TARGET_DRAFT_PRIMARY_SPEC="$PRIMARY_SPEC" \
+    TARGET_DRAFT_RETIRED_FILE="$RETIRED_FILE" \
+        "$VALIDATOR" "$@"
+}
+
+expect_pass() {
+    local name="$1"
+    shift
+    TESTS=$((TESTS + 1))
+    if ! "$@" >/dev/null; then
+        echo "not ok $TESTS - $name" >&2
+        exit 1
+    fi
+    echo "ok $TESTS - $name"
+}
+
+expect_fail() {
+    local name="$1"
+    local expected="$2"
+    local output
+    shift 2
+    TESTS=$((TESTS + 1))
+    if output="$("$@" 2>&1)"; then
+        echo "not ok $TESTS - $name (unexpected pass)" >&2
+        exit 1
+    fi
+    if ! printf '%s\n' "$output" | grep -Fq "$expected"; then
+        echo "not ok $TESTS - $name (missing error: $expected)" >&2
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+    echo "ok $TESTS - $name"
+}
+
+reset_fixtures
+expect_pass "valid exact declarations, plain/backticked IDs, and external test functions" run_validator
+
+reset_fixtures
+printf '%s\n' 'Ordinary prose about the Target Draft does not declare it again.' >> "$PRIMARY_SPEC"
+expect_pass "ordinary Target Draft prose is not a declaration" run_validator
+
+reset_fixtures
+printf '%s\n' \
+    '<!--' \
+    '**Target Draft**: `draft-17`' \
+    '**Identifier Semantics Reviewed For**: `draft-17`' \
+    '### `hidden-DRAFT_17-test`' \
+    '-->' >> "$PRIMARY_SPEC"
+expect_pass "HTML-commented declarations and IDs are ignored" run_validator
+
+reset_fixtures
+printf '%s\n' \
+    '# Canonical Tests' \
+    '<!-- **Target Draft**: `draft-18` -->' \
+    '<!-- **Identifier Semantics Reviewed For**: `draft-18` -->' \
+    '### `publish-without-subscriber`' \
+    '### publish-to-pending-subscription' > "$PRIMARY_SPEC"
+expect_fail "HTML-commented declarations do not count" "exactly one Target Draft declaration; found 0" run_validator
+
+reset_fixtures
+printf '%s\n' \
+    '```markdown' \
+    '**Target Draft**: `draft-17`' \
+    '**Identifier Semantics Reviewed For**: `draft-17`' \
+    '### publish-without-subscriber' \
+    'fn test_moqt_17_ignored () {}' \
+    '```' >> "$PRIMARY_SPEC"
+expect_pass "fenced declarations, IDs, and functions are ignored" run_validator
+
+reset_fixtures
+printf '%s\n' \
+    '```text' \
+    '<!-- literal unclosed comment inside example' \
+    '```' \
+    '### case-d18-after-fence' >> "$PRIMARY_SPEC"
+expect_fail "HTML comment syntax inside a fence cannot hide following IDs" "version-specific public heading ID" run_validator
+
+reset_fixtures
+printf '%s\n' \
+    '# Canonical Tests' \
+    '```markdown' \
+    '**Target Draft**: `draft-18`' \
+    '**Identifier Semantics Reviewed For**: `draft-18`' \
+    '```' \
+    '### publish-without-subscriber' \
+    '### publish-to-pending-subscription' > "$PRIMARY_SPEC"
+expect_fail "fenced declarations do not count" "exactly one Target Draft declaration; found 0" run_validator
+
+reset_fixtures
+printf '%s\n' 'Target Draft: draft-17' >> "$PRIMARY_SPEC"
+expect_fail "plain malformed duplicate target label" "exactly one Target Draft declaration; found 2" run_validator
+
+reset_fixtures
+printf '%s\n' '**Identifier Semantics Reviewed For** draft-17' >> "$PRIMARY_SPEC"
+expect_fail "malformed duplicate semantics label" "exactly one Identifier Semantics Reviewed For declaration; found 2" run_validator
+
+reset_fixtures
+printf '%s\n' \
+    '# Optional Profile' \
+    '**Target Draft**: `draft-18`' \
+    '**Identifier Semantics Reviewed For**: `draft-17`' > "$OPTIONAL_SPEC"
+expect_fail "stale optional semantics declaration" "malformed or stale Identifier Semantics Reviewed For declaration" run_validator "$OPTIONAL_SPEC"
+
+reset_fixtures
+printf '%s\n' '### `decorated-test` extra' >> "$PRIMARY_SPEC"
+expect_fail "decorated backticked heading attempt" "malformed canonical test heading" run_validator
+
+reset_fixtures
+printf '%s\n' '### decorated-test (extra)' >> "$PRIMARY_SPEC"
+expect_fail "decorated plain heading attempt" "malformed canonical test heading" run_validator
+
+reset_fixtures
+append_identifier_table_row '`decorated-table-test` extra'
+expect_fail "decorated first-column table attempt" "malformed canonical first-column table ID" run_validator
+
+reset_fixtures
+printf '%s\n' '### `case-d18-middle`' >> "$PRIMARY_SPEC"
+expect_fail "dNN token anywhere" "version-specific public heading ID" run_validator
+
+reset_fixtures
+printf '%s\n' '### case-draft-18-middle' >> "$PRIMARY_SPEC"
+expect_fail "draft-NN token anywhere" "version-specific public heading ID" run_validator
+
+reset_fixtures
+append_identifier_table_row 'case-DRAFT_18-middle'
+expect_fail "case-insensitive draft_NN token anywhere" "version-specific public first-column table ID" run_validator
+
+reset_fixtures
+append_identifier_table_row '`case-moqt18-middle`'
+expect_fail "moqtNN token anywhere" "version-specific public first-column table ID" run_validator
+
+reset_fixtures
+printf '%s\n' 'The API is `test_case_MoQt-18_middle (`.' >> "$PRIMARY_SPEC"
+expect_fail "case-insensitive moqt-NN function token" "version-specific public function 'test_case_MoQt-18_middle'" run_validator
+
+reset_fixtures
+printf '%s\n' 'fn test_case_moqt_18_middle   () {}' >> "$PRIMARY_SPEC"
+expect_fail "moqt_NN Rust function with whitespace" "version-specific public function 'test_case_moqt_18_middle'" run_validator
+
+reset_fixtures
+printf '%s\n' 'Protocol References: MoQT-17 and draft-ietf-moq-transport-17' >> "$PRIMARY_SPEC"
+expect_fail "mismatched formal reference" "uses 'MoQT-17'; target is draft-18" run_validator
+
+reset_fixtures
+printf '%s\n' '### duplicate-active-id' '### `duplicate-active-id`' >> "$PRIMARY_SPEC"
+expect_fail "duplicate active heading ID" "duplicate active canonical ID 'duplicate-active-id'" run_validator
+
+reset_fixtures
+printf '%s\n' '### duplicate-cross-surface' >> "$PRIMARY_SPEC"
+append_identifier_table_row 'duplicate-cross-surface'
+expect_fail "duplicate active ID across heading and table" "duplicate active canonical ID 'duplicate-cross-surface'" run_validator
+
+reset_fixtures
+printf '%s\n' '### publish-track-only' >> "$PRIMARY_SPEC"
+expect_fail "retired ID reused as active" "retired ID 'publish-track-only' is reused as an active canonical ID" run_validator
+
+reset_fixtures
+printf '%s\n' \
+    '# Canonical Tests' \
+    '**Target Draft**: `draft-18`' \
+    '**Identifier Semantics Reviewed For**: `draft-18`' \
+    '### publish-to-pending-subscription' \
+    '```markdown' \
+    '### publish-without-subscriber' \
+    '```' > "$PRIMARY_SPEC"
+expect_fail "fenced replacement heading is not active" "replacement 'publish-without-subscriber'" run_validator
+
+reset_fixtures
+rewrite_registry '(.retired_identifiers[] | select(.id == "publish-track-only")).replacement = "publish-track-only"'
+expect_fail "replacement differs from retired ID" "retired ID 'publish-track-only' must have a different replacement" run_validator
+
+reset_fixtures
+rewrite_registry '(.retired_identifiers[] | select(.id == "publish-track-only")).replacement = "missing-replacement"'
+expect_fail "replacement exists as active heading" "replacement 'missing-replacement' for retired ID 'publish-track-only' is not an active canonical heading ID" run_validator
+
+reset_fixtures
+rewrite_registry '.retired_identifiers += [.retired_identifiers[0]]'
+expect_fail "retired IDs are unique" "contains duplicate retired ID 'publish-track-only'" run_validator
+
+reset_fixtures
+rewrite_registry '.retired_identifiers |= map(select(.id != "publish-track-only"))'
+printf '%s\n' '### publish-track-only' >> "$PRIMARY_SPEC"
+expect_fail "deleted pinned tombstone cannot enable ID reuse" "pinned retired ID 'publish-track-only' is reused as an active canonical ID" run_validator
+
+reset_fixtures
+rewrite_registry '(.retired_identifiers[0].reason) = "Changed reason"'
+expect_fail "initial tombstone reason is pinned" "does not match the pinned initial tombstones" run_validator
+
+reset_fixtures
+rewrite_registry '(.retired_identifiers[0].last_known_implementation.commit) = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"'
+expect_fail "initial tombstone provenance is pinned" "does not match the pinned initial tombstones" run_validator
+
+reset_fixtures
+cp "$RETIRED_FILE" "$PREVIOUS_RETIRED_FILE"
+append_retirement "$PREVIOUS_RETIRED_FILE" "legacy-extra" "replacement-extra"
+expect_fail "previous-history tombstone deletion" "previous tombstone array is not an exact prefix" run_validator --previous-retired "$PREVIOUS_RETIRED_FILE"
+
+reset_fixtures
+cp "$RETIRED_FILE" "$PREVIOUS_RETIRED_FILE"
+append_retirement "$PREVIOUS_RETIRED_FILE" "legacy-extra-a" "replacement-extra-a"
+append_retirement "$PREVIOUS_RETIRED_FILE" "legacy-extra-b" "replacement-extra-b"
+append_retirement "$RETIRED_FILE" "legacy-extra-b" "replacement-extra-b"
+append_retirement "$RETIRED_FILE" "legacy-extra-a" "replacement-extra-a"
+printf '%s\n' '### replacement-extra-a' '### replacement-extra-b' >> "$PRIMARY_SPEC"
+expect_fail "previous-history set subset reordered" "previous tombstone array is not an exact prefix" run_validator --previous-retired "$PREVIOUS_RETIRED_FILE"
+
+reset_fixtures
+cp "$RETIRED_FILE" "$PREVIOUS_RETIRED_FILE"
+append_retirement "$RETIRED_FILE" "legacy-extra" "replacement-extra"
+printf '%s\n' '### replacement-extra' >> "$PRIMARY_SPEC"
+expect_pass "append-only retirement addition" run_validator --previous-retired "$PREVIOUS_RETIRED_FILE"
+
+reset_fixtures
+rewrite_registry '.initial_tombstone_pin = "changed"'
+expect_fail "initial tombstone pin is stable" "does not match the pinned initial tombstones" run_validator
+
+echo "1..$TESTS"

--- a/scripts/validate-target-draft.sh
+++ b/scripts/validate-target-draft.sh
@@ -10,16 +10,12 @@ PRIMARY_SPEC="${TARGET_DRAFT_PRIMARY_SPEC:-$ROOT_DIR/docs/tests/TEST-CASES.md}"
 RETIRED_FILE="${TARGET_DRAFT_RETIRED_FILE:-$ROOT_DIR/docs/tests/retired-test-identifiers.json}"
 REGISTRY_FORMAT="moqt-retired-test-identifiers"
 REGISTRY_VERSION=1
-INITIAL_TOMBSTONE_PIN="v1:publish-track-only>publish-without-subscriber;publish-track-subscribe>publish-to-pending-subscription"
-INITIAL_SOURCE_REPOSITORY="https://github.com/cloudflare/moq-rs"
-INITIAL_SOURCE_COMMIT="b01d3f6707e3a74f69905722b451a08cbb3364f3"
-INITIAL_REASON_WITHOUT_SUBSCRIBER="The legacy client/result scenario does not enforce the canonical Forward-State-aware object and PUBLISH_DONE lifecycle, including exact Stream Count and request-stream completion."
-INITIAL_REASON_PENDING_SUBSCRIPTION="The legacy client/result scenario does not enforce subscriber-first rendezvous, Forward State 1, exact object delivery, and counted-stream completion required by the canonical test."
 PREVIOUS_RETIRED_FILE=""
+PREVIOUS_SPEC_FILE=""
 SPEC_FILES=()
 
 usage() {
-    printf 'Usage: %s [--previous-retired <file>] [additional-spec-file ...]\n' "${0##*/}"
+    printf 'Usage: %s [--previous-retired <file>] [--previous-spec <file>] [additional-spec-file ...]\n' "${0##*/}"
 }
 
 while [ $# -gt 0 ]; do
@@ -27,6 +23,11 @@ while [ $# -gt 0 ]; do
         --previous-retired)
             [ $# -ge 2 ] || { echo "ERROR: --previous-retired requires a file" >&2; exit 1; }
             PREVIOUS_RETIRED_FILE="$2"
+            shift 2
+            ;;
+        --previous-spec)
+            [ $# -ge 2 ] || { echo "ERROR: --previous-spec requires a file" >&2; exit 1; }
+            PREVIOUS_SPEC_FILE="$2"
             shift 2
             ;;
         -h|--help)
@@ -60,6 +61,10 @@ if [ -n "$PREVIOUS_RETIRED_FILE" ] && [ ! -f "$PREVIOUS_RETIRED_FILE" ]; then
     echo "ERROR: previous retirement registry not found: $PREVIOUS_RETIRED_FILE" >&2
     exit 1
 fi
+if [ -n "$PREVIOUS_SPEC_FILE" ] && [ ! -f "$PREVIOUS_SPEC_FILE" ]; then
+    echo "ERROR: previous canonical specification not found: $PREVIOUS_SPEC_FILE" >&2
+    exit 1
+fi
 
 target="$(jq -er '.current_target | select(type == "string" and test("^draft-[0-9]+$"))' "$CONFIG_FILE" 2>/dev/null)" || {
     echo "ERROR: implementations.json.current_target must match draft-NN" >&2
@@ -68,8 +73,8 @@ target="$(jq -er '.current_target | select(type == "string" and test("^draft-[0-
 target_number="${target#draft-}"
 status=0
 ACTIVE_IDS_FILE="$(mktemp "${TMPDIR:-/tmp}/active-test-identifiers.XXXXXX")"
-ACTIVE_HEADING_IDS_FILE="$(mktemp "${TMPDIR:-/tmp}/active-heading-identifiers.XXXXXX")"
-trap 'rm -f "$ACTIVE_IDS_FILE" "$ACTIVE_HEADING_IDS_FILE"' EXIT
+PREVIOUS_ACTIVE_IDS_FILE="$(mktemp "${TMPDIR:-/tmp}/previous-active-test-identifiers.XXXXXX")"
+trap 'rm -f "$ACTIVE_IDS_FILE" "$PREVIOUS_ACTIVE_IDS_FILE"' EXIT
 
 sanitize_markdown() {
     local source="$1"
@@ -159,20 +164,73 @@ check_public_name() {
 record_active_id() {
     local spec="$1"
     local line_number="$2"
-    local kind="$3"
-    local public_name="$4"
+    local public_name="$3"
+    local active_ids_file="$4"
+    local enforce_policy="$5"
 
-    check_public_name "$spec" "$line_number" "$kind" "$public_name"
-    printf '%s\n' "$public_name" >> "$ACTIVE_IDS_FILE"
-    if [ "$kind" = "heading ID" ]; then
-        printf '%s\n' "$public_name" >> "$ACTIVE_HEADING_IDS_FILE"
+    if [ "$enforce_policy" = true ]; then
+        check_public_name "$spec" "$line_number" "heading ID" "$public_name"
     fi
+    printf '%s\n' "$public_name" >> "$active_ids_file"
+}
+
+scan_active_ids() {
+    local spec="$1"
+    local clean_spec="$2"
+    local active_ids_file="$3"
+    local enforce_policy="$4"
+    local line_number line public_name first_cell heading_content
+    local in_identifier_table=false
+
+    line_number=0
+    while IFS= read -r line || [ -n "$line" ]; do
+        line_number=$((line_number + 1))
+
+        if printf '%s\n' "$line" | grep -Eq '^ {0,3}###'; then
+            if printf '%s\n' "$line" | grep -Eq '^ {0,3}###[[:space:]]+(`([a-z][a-z0-9-]*)`|[a-z][a-z0-9-]*)[[:space:]]*$'; then
+                public_name="$(printf '%s\n' "$line" | grep -Eo '[a-z][a-z0-9-]*')"
+                record_active_id "$spec" "$line_number" "$public_name" "$active_ids_file" "$enforce_policy"
+            else
+                heading_content="${line#*###}"
+                heading_content="${heading_content#"${heading_content%%[![:space:]]*}"}"
+                if [ "$enforce_policy" = true ] &&
+                   { [[ "$heading_content" == *"\`"* ]] ||
+                     [[ "$heading_content" != *" "* ]] ||
+                     printf '%s\n' "$heading_content" | grep -Eq '^[a-z]|^[A-Za-z0-9_]*[-_][A-Za-z0-9_-]*'; }; then
+                    check_public_name "$spec" "$line_number" "heading ID" "$heading_content"
+                    echo "ERROR: $spec:$line_number has malformed canonical test heading '$heading_content'" >&2
+                    status=1
+                fi
+            fi
+        fi
+
+        if [[ "$line" == *"|"* ]] && printf '%s\n' "$line" | grep -Eq '^[[:space:]]*\|'; then
+            first_cell="${line#*|}"
+            first_cell="${first_cell%%|*}"
+            if printf '%s\n' "$first_cell" | grep -Eqi '^[[:space:]]*(identifier|test|test[[:space:]_-]+id)[[:space:]]*$'; then
+                in_identifier_table=true
+                continue
+            fi
+            if [ "$in_identifier_table" = true ]; then
+                if printf '%s\n' "$first_cell" | grep -Eq '^[[:space:]]*:?-+:?[[:space:]]*$'; then
+                    continue
+                fi
+                if [ "$enforce_policy" = true ]; then
+                    check_public_name "$spec" "$line_number" "test-ID table entry" "$first_cell"
+                fi
+                continue
+            fi
+        else
+            in_identifier_table=false
+        fi
+
+    done < "$clean_spec"
 }
 
 check_spec() {
     local spec="$1"
-    local clean_spec line_number line token public_name function_token first_cell heading_content
-    local in_identifier_table=false
+    local active_ids_file="$2"
+    local clean_spec line_number line token
 
     clean_spec="$(mktemp "${TMPDIR:-/tmp}/canonical-test-spec.XXXXXX")"
     sanitize_markdown "$spec" > "$clean_spec"
@@ -194,64 +252,7 @@ check_spec() {
         done < <(printf '%s\n' "$line" | grep -Eo 'MoQT-[0-9]+|draft-ietf-moq-transport-[0-9]+' || true)
     done < <(grep -En 'MoQT-[0-9]+|draft-ietf-moq-transport-[0-9]+' "$clean_spec" || true)
 
-    line_number=0
-    while IFS= read -r line || [ -n "$line" ]; do
-        line_number=$((line_number + 1))
-
-        if [[ "$line" == "###"* ]]; then
-            if printf '%s\n' "$line" | grep -Eq '^###[[:space:]]+(`([a-z][a-z0-9-]*)`|[a-z][a-z0-9-]*)[[:space:]]*$'; then
-                public_name="$(printf '%s\n' "$line" | grep -Eo '[a-z][a-z0-9-]*')"
-                record_active_id "$spec" "$line_number" "heading ID" "$public_name"
-            else
-                heading_content="${line#\#\#\#}"
-                heading_content="${heading_content#"${heading_content%%[![:space:]]*}"}"
-                if [[ "$heading_content" == *"\`"* ]] ||
-                   [[ "$heading_content" != *" "* ]] ||
-                   printf '%s\n' "$heading_content" | grep -Eq '^[a-z]|^[A-Za-z0-9_]*[-_][A-Za-z0-9_-]*'; then
-                    check_public_name "$spec" "$line_number" "heading ID" "$heading_content"
-                    echo "ERROR: $spec:$line_number has malformed canonical test heading '$heading_content'" >&2
-                    status=1
-                fi
-            fi
-        fi
-
-        if [[ "$line" == *"|"* ]] && printf '%s\n' "$line" | grep -Eq '^[[:space:]]*\|'; then
-            first_cell="${line#*|}"
-            first_cell="${first_cell%%|*}"
-            if printf '%s\n' "$first_cell" | grep -Eqi '^[[:space:]]*(identifier|test|test[[:space:]_-]+id)[[:space:]]*$'; then
-                in_identifier_table=true
-                continue
-            fi
-            if [ "$in_identifier_table" = true ]; then
-                if printf '%s\n' "$first_cell" | grep -Eq '^[[:space:]]*:?-+:?[[:space:]]*$'; then
-                    continue
-                fi
-                if printf '%s\n' "$first_cell" | grep -Eq '^[[:space:]]*(`[a-z][a-z0-9-]*`|[a-z][a-z0-9-]*)[[:space:]]*$'; then
-                    public_name="$(printf '%s\n' "$first_cell" | grep -Eo '[a-z][a-z0-9-]*')"
-                    record_active_id "$spec" "$line_number" "first-column table ID" "$public_name"
-                else
-                    check_public_name "$spec" "$line_number" "first-column table ID" "$first_cell"
-                    echo "ERROR: $spec:$line_number has malformed canonical first-column table ID '$first_cell'" >&2
-                    status=1
-                fi
-                continue
-            fi
-        else
-            in_identifier_table=false
-        fi
-
-        while IFS= read -r function_token; do
-            [ -n "$function_token" ] || continue
-            public_name="$(printf '%s\n' "$function_token" | grep -Eo 'test_[A-Za-z0-9_-]+')"
-            check_public_name "$spec" "$line_number" "function" "$public_name"
-        done < <(printf '%s\n' "$line" | grep -Eo '`test_[A-Za-z0-9_-]+[[:space:]]*\(' || true)
-
-        while IFS= read -r function_token; do
-            [ -n "$function_token" ] || continue
-            public_name="$(printf '%s\n' "$function_token" | grep -Eo 'test_[A-Za-z0-9_-]+')"
-            check_public_name "$spec" "$line_number" "function" "$public_name"
-        done < <(printf '%s\n' "$line" | grep -Eo 'fn[[:space:]]+test_[A-Za-z0-9_-]+[[:space:]]*\(' || true)
-    done < "$clean_spec"
+    scan_active_ids "$spec" "$clean_spec" "$active_ids_file" true
 
     rm -f "$clean_spec"
 }
@@ -271,66 +272,64 @@ registry_has_valid_shape() {
 
     jq -e --arg format "$REGISTRY_FORMAT" --argjson version "$REGISTRY_VERSION" '
         type == "object" and
+        (keys | sort) == ["format", "format_version", "retired_identifiers"] and
         .format == $format and
         .format_version == $version and
-        (.initial_tombstone_pin | type) == "string" and
         (.retired_identifiers | type) == "array" and
         all(.retired_identifiers[];
+            (keys | sort) == ["id", "last_known_profile_revision", "last_known_target", "reason", "replacement"] and
             ((.id | type) == "string" and (.id | test("^[a-z][a-z0-9-]*$"))) and
             ((.last_known_target | type) == "string" and (.last_known_target | test("^draft-[0-9]+$"))) and
             ((.last_known_profile_revision | type) == "string" and (.last_known_profile_revision | length) > 0) and
-            ((.last_known_implementation | type) == "object") and
-            ((.last_known_implementation.repository | type) == "string" and (.last_known_implementation.repository | length) > 0) and
-            ((.last_known_implementation.commit | type) == "string" and (.last_known_implementation.commit | test("^[0-9a-f]{40}$"))) and
-            ((.last_known_implementation.image_digest | type) == "string" and
-                ((.last_known_implementation.image_digest == "unknown") or
-                 (.last_known_implementation.image_digest | test("^sha256:[0-9a-f]{64}$")))) and
             ((.reason | type) == "string" and (.reason | length) > 0) and
-            ((.replacement | type) == "string" and (.replacement | test("^[a-z][a-z0-9-]*$")))
+            ((.replacement == null) or
+             ((.replacement | type) == "string" and (.replacement | test("^[a-z][a-z0-9-]*$"))))
         )
     ' "$registry" >/dev/null 2>&1
 }
 
-check_initial_tombstones() {
-    if ! jq -e \
-        --arg pin "$INITIAL_TOMBSTONE_PIN" \
-        --arg repository "$INITIAL_SOURCE_REPOSITORY" \
-        --arg commit "$INITIAL_SOURCE_COMMIT" \
-        --arg reason_without_subscriber "$INITIAL_REASON_WITHOUT_SUBSCRIBER" \
-        --arg reason_pending_subscription "$INITIAL_REASON_PENDING_SUBSCRIPTION" '
-        .initial_tombstone_pin == $pin and
-        .retired_identifiers[0] == {
-            id: "publish-track-only",
-            last_known_target: "draft-18",
-            last_known_profile_revision: "legacy-unversioned",
-            last_known_implementation: {
-                repository: $repository,
-                commit: $commit,
-                image_digest: "unknown"
-            },
-            reason: $reason_without_subscriber,
-            replacement: "publish-without-subscriber"
-        } and
-        .retired_identifiers[1] == {
-            id: "publish-track-subscribe",
-            last_known_target: "draft-18",
-            last_known_profile_revision: "legacy-unversioned",
-            last_known_implementation: {
-                repository: $repository,
-                commit: $commit,
-                image_digest: "unknown"
-            },
-            reason: $reason_pending_subscription,
-            replacement: "publish-to-pending-subscription"
-        }
-    ' "$RETIRED_FILE" >/dev/null 2>&1; then
-        echo "ERROR: $RETIRED_FILE does not match the pinned initial tombstones" >&2
-        status=1
-    fi
+check_retirement_chains() {
+    local retired_id current replacement path
+
+    while IFS= read -r retired_id; do
+        [ -n "$retired_id" ] || continue
+        if grep -Fqx "$retired_id" "$ACTIVE_IDS_FILE"; then
+            echo "ERROR: retired ID '$retired_id' is reused as an active canonical ID" >&2
+            status=1
+        fi
+
+        current="$retired_id"
+        path="|$retired_id|"
+        while true; do
+            replacement="$(jq -r --arg id "$current" '.retired_identifiers[] | select(.id == $id) | if .replacement == null then "__NO_REPLACEMENT__" else .replacement end' "$RETIRED_FILE")"
+            if [ "$replacement" = "__NO_REPLACEMENT__" ]; then
+                if [ "$current" != "$retired_id" ]; then
+                    echo "ERROR: retirement chain from '$retired_id' terminates at retired ID '$current' with no replacement" >&2
+                    status=1
+                fi
+                break
+            fi
+            if grep -Fqx "$replacement" "$ACTIVE_IDS_FILE"; then
+                break
+            fi
+            if ! jq -e --arg id "$replacement" 'any(.retired_identifiers[]; .id == $id)' "$RETIRED_FILE" >/dev/null; then
+                echo "ERROR: retirement chain from '$retired_id' does not terminate at an active canonical ID" >&2
+                status=1
+                break
+            fi
+            if [[ "$path" == *"|$replacement|"* ]]; then
+                echo "ERROR: retirement chain from '$retired_id' contains a cycle at '$replacement'" >&2
+                status=1
+                break
+            fi
+            path="$path$replacement|"
+            current="$replacement"
+        done
+    done < <(jq -r '.retired_identifiers[].id' "$RETIRED_FILE")
 }
 
 check_retired_registry() {
-    local duplicate retired_id replacement pinned_id
+    local duplicate
 
     if ! jq empty "$RETIRED_FILE" 2>/dev/null; then
         echo "ERROR: $RETIRED_FILE is not valid JSON" >&2
@@ -343,36 +342,13 @@ check_retired_registry() {
         return
     fi
 
-    check_initial_tombstones
-
     while IFS= read -r duplicate; do
         [ -n "$duplicate" ] || continue
         echo "ERROR: $RETIRED_FILE contains duplicate retired ID '$duplicate'" >&2
         status=1
     done < <(jq -r '.retired_identifiers | group_by(.id)[] | select(length > 1) | .[0].id' "$RETIRED_FILE")
 
-    while IFS=$'\t' read -r retired_id replacement; do
-        [ -n "$retired_id" ] || continue
-        if [ "$retired_id" = "$replacement" ]; then
-            echo "ERROR: retired ID '$retired_id' must have a different replacement" >&2
-            status=1
-        fi
-        if grep -Fqx "$retired_id" "$ACTIVE_IDS_FILE"; then
-            echo "ERROR: retired ID '$retired_id' is reused as an active canonical ID" >&2
-            status=1
-        fi
-        if ! grep -Fqx "$replacement" "$ACTIVE_HEADING_IDS_FILE"; then
-            echo "ERROR: replacement '$replacement' for retired ID '$retired_id' is not an active canonical heading ID" >&2
-            status=1
-        fi
-    done < <(jq -r '.retired_identifiers[] | [.id, .replacement] | @tsv' "$RETIRED_FILE")
-
-    for pinned_id in publish-track-only publish-track-subscribe; do
-        if grep -Fqx "$pinned_id" "$ACTIVE_IDS_FILE"; then
-            echo "ERROR: pinned retired ID '$pinned_id' is reused as an active canonical ID" >&2
-            status=1
-        fi
-    done
+    check_retirement_chains
 }
 
 check_previous_registry() {
@@ -397,19 +373,44 @@ check_previous_registry() {
     fi
 }
 
-check_spec "$PRIMARY_SPEC"
+check_previous_spec() {
+    local clean_spec previous_id
+
+    if [ -z "$PREVIOUS_SPEC_FILE" ]; then
+        return 0
+    fi
+
+    clean_spec="$(mktemp "${TMPDIR:-/tmp}/previous-canonical-test-spec.XXXXXX")"
+    sanitize_markdown "$PREVIOUS_SPEC_FILE" > "$clean_spec"
+    scan_active_ids "$PREVIOUS_SPEC_FILE" "$clean_spec" "$PREVIOUS_ACTIVE_IDS_FILE" false
+    rm -f "$clean_spec"
+
+    while IFS= read -r previous_id; do
+        [ -n "$previous_id" ] || continue
+        if grep -Fqx "$previous_id" "$ACTIVE_IDS_FILE"; then
+            continue
+        fi
+        if ! jq -e --arg id "$previous_id" 'any(.retired_identifiers[]; .id == $id)' "$RETIRED_FILE" >/dev/null; then
+            echo "ERROR: previous canonical ID '$previous_id' is missing without a retirement tombstone" >&2
+            status=1
+        fi
+    done < <(jq -Rrs 'split("\n") | map(select(length > 0)) | unique[]' "$PREVIOUS_ACTIVE_IDS_FILE")
+}
+
+check_spec "$PRIMARY_SPEC" "$ACTIVE_IDS_FILE"
 for spec in "${SPEC_FILES[@]}"; do
     if [ ! -f "$spec" ]; then
         echo "ERROR: additional spec file not found: $spec" >&2
         status=1
         continue
     fi
-    check_spec "$spec"
+    check_spec "$spec" /dev/null
 done
 
 check_duplicate_active_ids
 check_retired_registry
 check_previous_registry
+check_previous_spec
 
 if [ "$status" -eq 0 ]; then
     echo "Target-draft policy valid: $target"

--- a/scripts/validate-target-draft.sh
+++ b/scripts/validate-target-draft.sh
@@ -1,0 +1,418 @@
+#!/bin/bash
+# Validate canonical test specifications against implementations.json.current_target.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONFIG_FILE="${TARGET_DRAFT_CONFIG_FILE:-$ROOT_DIR/implementations.json}"
+PRIMARY_SPEC="${TARGET_DRAFT_PRIMARY_SPEC:-$ROOT_DIR/docs/tests/TEST-CASES.md}"
+RETIRED_FILE="${TARGET_DRAFT_RETIRED_FILE:-$ROOT_DIR/docs/tests/retired-test-identifiers.json}"
+REGISTRY_FORMAT="moqt-retired-test-identifiers"
+REGISTRY_VERSION=1
+INITIAL_TOMBSTONE_PIN="v1:publish-track-only>publish-without-subscriber;publish-track-subscribe>publish-to-pending-subscription"
+INITIAL_SOURCE_REPOSITORY="https://github.com/cloudflare/moq-rs"
+INITIAL_SOURCE_COMMIT="b01d3f6707e3a74f69905722b451a08cbb3364f3"
+INITIAL_REASON_WITHOUT_SUBSCRIBER="The legacy client/result scenario does not enforce the canonical Forward-State-aware object and PUBLISH_DONE lifecycle, including exact Stream Count and request-stream completion."
+INITIAL_REASON_PENDING_SUBSCRIPTION="The legacy client/result scenario does not enforce subscriber-first rendezvous, Forward State 1, exact object delivery, and counted-stream completion required by the canonical test."
+PREVIOUS_RETIRED_FILE=""
+SPEC_FILES=()
+
+usage() {
+    printf 'Usage: %s [--previous-retired <file>] [additional-spec-file ...]\n' "${0##*/}"
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --previous-retired)
+            [ $# -ge 2 ] || { echo "ERROR: --previous-retired requires a file" >&2; exit 1; }
+            PREVIOUS_RETIRED_FILE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            while [ $# -gt 0 ]; do
+                SPEC_FILES+=("$1")
+                shift
+            done
+            ;;
+        -*)
+            echo "ERROR: unknown option: $1" >&2
+            exit 1
+            ;;
+        *)
+            SPEC_FILES+=("$1")
+            shift
+            ;;
+    esac
+done
+
+command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required" >&2; exit 1; }
+command -v grep >/dev/null 2>&1 || { echo "ERROR: grep is required" >&2; exit 1; }
+[ -f "$CONFIG_FILE" ] || { echo "ERROR: $CONFIG_FILE not found" >&2; exit 1; }
+[ -f "$PRIMARY_SPEC" ] || { echo "ERROR: $PRIMARY_SPEC not found" >&2; exit 1; }
+[ -f "$RETIRED_FILE" ] || { echo "ERROR: $RETIRED_FILE not found" >&2; exit 1; }
+if [ -n "$PREVIOUS_RETIRED_FILE" ] && [ ! -f "$PREVIOUS_RETIRED_FILE" ]; then
+    echo "ERROR: previous retirement registry not found: $PREVIOUS_RETIRED_FILE" >&2
+    exit 1
+fi
+
+target="$(jq -er '.current_target | select(type == "string" and test("^draft-[0-9]+$"))' "$CONFIG_FILE" 2>/dev/null)" || {
+    echo "ERROR: implementations.json.current_target must match draft-NN" >&2
+    exit 1
+}
+target_number="${target#draft-}"
+status=0
+ACTIVE_IDS_FILE="$(mktemp "${TMPDIR:-/tmp}/active-test-identifiers.XXXXXX")"
+ACTIVE_HEADING_IDS_FILE="$(mktemp "${TMPDIR:-/tmp}/active-heading-identifiers.XXXXXX")"
+trap 'rm -f "$ACTIVE_IDS_FILE" "$ACTIVE_HEADING_IDS_FILE"' EXIT
+
+sanitize_markdown() {
+    local source="$1"
+    local line remaining output before
+    local in_comment=false
+    local fence=""
+
+    while IFS= read -r line || [ -n "$line" ]; do
+        if [ -n "$fence" ]; then
+            if { [ "$fence" = "backtick" ] && printf '%s\n' "$line" | grep -Eq '^[[:space:]]*`{3,}[[:space:]]*$'; } ||
+               { [ "$fence" = "tilde" ] && printf '%s\n' "$line" | grep -Eq '^[[:space:]]*~{3,}[[:space:]]*$'; }; then
+                fence=""
+            fi
+            printf '\n'
+            continue
+        fi
+
+        remaining="$line"
+        output=""
+        while [ -n "$remaining" ]; do
+            if [ "$in_comment" = true ]; then
+                if [[ "$remaining" == *"-->"* ]]; then
+                    remaining="${remaining#*-->}"
+                    in_comment=false
+                else
+                    remaining=""
+                fi
+            elif [[ "$remaining" == *"<!--"* ]]; then
+                before="${remaining%%<!--*}"
+                output="$output$before"
+                remaining="${remaining#*<!--}"
+                in_comment=true
+            else
+                output="$output$remaining"
+                remaining=""
+            fi
+        done
+
+        if printf '%s\n' "$output" | grep -Eq '^[[:space:]]*`{3,}'; then
+            fence="backtick"
+            printf '\n'
+        elif printf '%s\n' "$output" | grep -Eq '^[[:space:]]*~{3,}'; then
+            fence="tilde"
+            printf '\n'
+        else
+            printf '%s\n' "$output"
+        fi
+    done < "$source"
+}
+
+check_declaration() {
+    local display_spec="$1"
+    local clean_spec="$2"
+    local label="$3"
+    local expected candidate_pattern count actual
+
+    expected="**$label**: \`$target\`"
+    case "$label" in
+        "Target Draft") candidate_pattern='^[[:space:]]*(\*\*[[:space:]]*Target[[:space:]]+Draft[[:space:]]*\*\*|Target[[:space:]]+Draft[[:space:]]*:)' ;;
+        "Identifier Semantics Reviewed For") candidate_pattern='^[[:space:]]*(\*\*[[:space:]]*Identifier[[:space:]]+Semantics[[:space:]]+Reviewed[[:space:]]+For[[:space:]]*\*\*|Identifier[[:space:]]+Semantics[[:space:]]+Reviewed[[:space:]]+For[[:space:]]*:)' ;;
+        *) echo "ERROR: unsupported declaration label: $label" >&2; exit 1 ;;
+    esac
+    count="$(grep -Eic "$candidate_pattern" "$clean_spec" || true)"
+
+    if [ "$count" -ne 1 ]; then
+        echo "ERROR: $display_spec must contain exactly one $label declaration; found $count" >&2
+        status=1
+    elif [ "$(grep -Fxc "$expected" "$clean_spec" || true)" -ne 1 ]; then
+        actual="$(grep -Ei "$candidate_pattern" "$clean_spec")"
+        echo "ERROR: $display_spec has malformed or stale $label declaration '$actual'; expected '$expected'" >&2
+        status=1
+    fi
+}
+
+check_public_name() {
+    local spec="$1"
+    local line_number="$2"
+    local kind="$3"
+    local public_name="$4"
+
+    if printf '%s\n' "$public_name" | grep -Eqi 'd[0-9]+|draft[-_][0-9]+|moqt[-_]?[0-9]+'; then
+        echo "ERROR: $spec:$line_number has version-specific public $kind '$public_name'" >&2
+        status=1
+    fi
+}
+
+record_active_id() {
+    local spec="$1"
+    local line_number="$2"
+    local kind="$3"
+    local public_name="$4"
+
+    check_public_name "$spec" "$line_number" "$kind" "$public_name"
+    printf '%s\n' "$public_name" >> "$ACTIVE_IDS_FILE"
+    if [ "$kind" = "heading ID" ]; then
+        printf '%s\n' "$public_name" >> "$ACTIVE_HEADING_IDS_FILE"
+    fi
+}
+
+check_spec() {
+    local spec="$1"
+    local clean_spec line_number line token public_name function_token first_cell heading_content
+    local in_identifier_table=false
+
+    clean_spec="$(mktemp "${TMPDIR:-/tmp}/canonical-test-spec.XXXXXX")"
+    sanitize_markdown "$spec" > "$clean_spec"
+
+    check_declaration "$spec" "$clean_spec" "Target Draft"
+    check_declaration "$spec" "$clean_spec" "Identifier Semantics Reviewed For"
+
+    while IFS=: read -r line_number line; do
+        [ -n "$line_number" ] || continue
+        while IFS= read -r token; do
+            [ -n "$token" ] || continue
+            case "$token" in
+                "MoQT-$target_number"|"draft-ietf-moq-transport-$target_number") ;;
+                *)
+                    echo "ERROR: $spec:$line_number uses '$token'; target is $target" >&2
+                    status=1
+                    ;;
+            esac
+        done < <(printf '%s\n' "$line" | grep -Eo 'MoQT-[0-9]+|draft-ietf-moq-transport-[0-9]+' || true)
+    done < <(grep -En 'MoQT-[0-9]+|draft-ietf-moq-transport-[0-9]+' "$clean_spec" || true)
+
+    line_number=0
+    while IFS= read -r line || [ -n "$line" ]; do
+        line_number=$((line_number + 1))
+
+        if [[ "$line" == "###"* ]]; then
+            if printf '%s\n' "$line" | grep -Eq '^###[[:space:]]+(`([a-z][a-z0-9-]*)`|[a-z][a-z0-9-]*)[[:space:]]*$'; then
+                public_name="$(printf '%s\n' "$line" | grep -Eo '[a-z][a-z0-9-]*')"
+                record_active_id "$spec" "$line_number" "heading ID" "$public_name"
+            else
+                heading_content="${line#\#\#\#}"
+                heading_content="${heading_content#"${heading_content%%[![:space:]]*}"}"
+                if [[ "$heading_content" == *"\`"* ]] ||
+                   [[ "$heading_content" != *" "* ]] ||
+                   printf '%s\n' "$heading_content" | grep -Eq '^[a-z]|^[A-Za-z0-9_]*[-_][A-Za-z0-9_-]*'; then
+                    check_public_name "$spec" "$line_number" "heading ID" "$heading_content"
+                    echo "ERROR: $spec:$line_number has malformed canonical test heading '$heading_content'" >&2
+                    status=1
+                fi
+            fi
+        fi
+
+        if [[ "$line" == *"|"* ]] && printf '%s\n' "$line" | grep -Eq '^[[:space:]]*\|'; then
+            first_cell="${line#*|}"
+            first_cell="${first_cell%%|*}"
+            if printf '%s\n' "$first_cell" | grep -Eqi '^[[:space:]]*(identifier|test|test[[:space:]_-]+id)[[:space:]]*$'; then
+                in_identifier_table=true
+                continue
+            fi
+            if [ "$in_identifier_table" = true ]; then
+                if printf '%s\n' "$first_cell" | grep -Eq '^[[:space:]]*:?-+:?[[:space:]]*$'; then
+                    continue
+                fi
+                if printf '%s\n' "$first_cell" | grep -Eq '^[[:space:]]*(`[a-z][a-z0-9-]*`|[a-z][a-z0-9-]*)[[:space:]]*$'; then
+                    public_name="$(printf '%s\n' "$first_cell" | grep -Eo '[a-z][a-z0-9-]*')"
+                    record_active_id "$spec" "$line_number" "first-column table ID" "$public_name"
+                else
+                    check_public_name "$spec" "$line_number" "first-column table ID" "$first_cell"
+                    echo "ERROR: $spec:$line_number has malformed canonical first-column table ID '$first_cell'" >&2
+                    status=1
+                fi
+                continue
+            fi
+        else
+            in_identifier_table=false
+        fi
+
+        while IFS= read -r function_token; do
+            [ -n "$function_token" ] || continue
+            public_name="$(printf '%s\n' "$function_token" | grep -Eo 'test_[A-Za-z0-9_-]+')"
+            check_public_name "$spec" "$line_number" "function" "$public_name"
+        done < <(printf '%s\n' "$line" | grep -Eo '`test_[A-Za-z0-9_-]+[[:space:]]*\(' || true)
+
+        while IFS= read -r function_token; do
+            [ -n "$function_token" ] || continue
+            public_name="$(printf '%s\n' "$function_token" | grep -Eo 'test_[A-Za-z0-9_-]+')"
+            check_public_name "$spec" "$line_number" "function" "$public_name"
+        done < <(printf '%s\n' "$line" | grep -Eo 'fn[[:space:]]+test_[A-Za-z0-9_-]+[[:space:]]*\(' || true)
+    done < "$clean_spec"
+
+    rm -f "$clean_spec"
+}
+
+check_duplicate_active_ids() {
+    local duplicate
+
+    while IFS= read -r duplicate; do
+        [ -n "$duplicate" ] || continue
+        echo "ERROR: duplicate active canonical ID '$duplicate'" >&2
+        status=1
+    done < <(jq -Rrs 'split("\n") | map(select(length > 0)) | group_by(.)[] | select(length > 1) | .[0]' "$ACTIVE_IDS_FILE")
+}
+
+registry_has_valid_shape() {
+    local registry="$1"
+
+    jq -e --arg format "$REGISTRY_FORMAT" --argjson version "$REGISTRY_VERSION" '
+        type == "object" and
+        .format == $format and
+        .format_version == $version and
+        (.initial_tombstone_pin | type) == "string" and
+        (.retired_identifiers | type) == "array" and
+        all(.retired_identifiers[];
+            ((.id | type) == "string" and (.id | test("^[a-z][a-z0-9-]*$"))) and
+            ((.last_known_target | type) == "string" and (.last_known_target | test("^draft-[0-9]+$"))) and
+            ((.last_known_profile_revision | type) == "string" and (.last_known_profile_revision | length) > 0) and
+            ((.last_known_implementation | type) == "object") and
+            ((.last_known_implementation.repository | type) == "string" and (.last_known_implementation.repository | length) > 0) and
+            ((.last_known_implementation.commit | type) == "string" and (.last_known_implementation.commit | test("^[0-9a-f]{40}$"))) and
+            ((.last_known_implementation.image_digest | type) == "string" and
+                ((.last_known_implementation.image_digest == "unknown") or
+                 (.last_known_implementation.image_digest | test("^sha256:[0-9a-f]{64}$")))) and
+            ((.reason | type) == "string" and (.reason | length) > 0) and
+            ((.replacement | type) == "string" and (.replacement | test("^[a-z][a-z0-9-]*$")))
+        )
+    ' "$registry" >/dev/null 2>&1
+}
+
+check_initial_tombstones() {
+    if ! jq -e \
+        --arg pin "$INITIAL_TOMBSTONE_PIN" \
+        --arg repository "$INITIAL_SOURCE_REPOSITORY" \
+        --arg commit "$INITIAL_SOURCE_COMMIT" \
+        --arg reason_without_subscriber "$INITIAL_REASON_WITHOUT_SUBSCRIBER" \
+        --arg reason_pending_subscription "$INITIAL_REASON_PENDING_SUBSCRIPTION" '
+        .initial_tombstone_pin == $pin and
+        .retired_identifiers[0] == {
+            id: "publish-track-only",
+            last_known_target: "draft-18",
+            last_known_profile_revision: "legacy-unversioned",
+            last_known_implementation: {
+                repository: $repository,
+                commit: $commit,
+                image_digest: "unknown"
+            },
+            reason: $reason_without_subscriber,
+            replacement: "publish-without-subscriber"
+        } and
+        .retired_identifiers[1] == {
+            id: "publish-track-subscribe",
+            last_known_target: "draft-18",
+            last_known_profile_revision: "legacy-unversioned",
+            last_known_implementation: {
+                repository: $repository,
+                commit: $commit,
+                image_digest: "unknown"
+            },
+            reason: $reason_pending_subscription,
+            replacement: "publish-to-pending-subscription"
+        }
+    ' "$RETIRED_FILE" >/dev/null 2>&1; then
+        echo "ERROR: $RETIRED_FILE does not match the pinned initial tombstones" >&2
+        status=1
+    fi
+}
+
+check_retired_registry() {
+    local duplicate retired_id replacement pinned_id
+
+    if ! jq empty "$RETIRED_FILE" 2>/dev/null; then
+        echo "ERROR: $RETIRED_FILE is not valid JSON" >&2
+        status=1
+        return
+    fi
+    if ! registry_has_valid_shape "$RETIRED_FILE"; then
+        echo "ERROR: $RETIRED_FILE has an invalid registry format or retirement record" >&2
+        status=1
+        return
+    fi
+
+    check_initial_tombstones
+
+    while IFS= read -r duplicate; do
+        [ -n "$duplicate" ] || continue
+        echo "ERROR: $RETIRED_FILE contains duplicate retired ID '$duplicate'" >&2
+        status=1
+    done < <(jq -r '.retired_identifiers | group_by(.id)[] | select(length > 1) | .[0].id' "$RETIRED_FILE")
+
+    while IFS=$'\t' read -r retired_id replacement; do
+        [ -n "$retired_id" ] || continue
+        if [ "$retired_id" = "$replacement" ]; then
+            echo "ERROR: retired ID '$retired_id' must have a different replacement" >&2
+            status=1
+        fi
+        if grep -Fqx "$retired_id" "$ACTIVE_IDS_FILE"; then
+            echo "ERROR: retired ID '$retired_id' is reused as an active canonical ID" >&2
+            status=1
+        fi
+        if ! grep -Fqx "$replacement" "$ACTIVE_HEADING_IDS_FILE"; then
+            echo "ERROR: replacement '$replacement' for retired ID '$retired_id' is not an active canonical heading ID" >&2
+            status=1
+        fi
+    done < <(jq -r '.retired_identifiers[] | [.id, .replacement] | @tsv' "$RETIRED_FILE")
+
+    for pinned_id in publish-track-only publish-track-subscribe; do
+        if grep -Fqx "$pinned_id" "$ACTIVE_IDS_FILE"; then
+            echo "ERROR: pinned retired ID '$pinned_id' is reused as an active canonical ID" >&2
+            status=1
+        fi
+    done
+}
+
+check_previous_registry() {
+    if [ -z "$PREVIOUS_RETIRED_FILE" ]; then
+        return 0
+    fi
+
+    if ! jq empty "$PREVIOUS_RETIRED_FILE" 2>/dev/null || ! registry_has_valid_shape "$PREVIOUS_RETIRED_FILE"; then
+        echo "ERROR: previous retirement registry has an invalid format: $PREVIOUS_RETIRED_FILE" >&2
+        status=1
+        return
+    fi
+    if ! jq -e --slurpfile current "$RETIRED_FILE" '
+        . as $previous |
+        ($previous.retired_identifiers | length) as $previous_length |
+        ($previous_length <= ($current[0].retired_identifiers | length)) and
+        all(range(0; $previous_length); . as $index |
+            $current[0].retired_identifiers[$index] == $previous.retired_identifiers[$index])
+    ' "$PREVIOUS_RETIRED_FILE" >/dev/null 2>&1; then
+        echo "ERROR: retirement registry is not append-only; the previous tombstone array is not an exact prefix" >&2
+        status=1
+    fi
+}
+
+check_spec "$PRIMARY_SPEC"
+for spec in "${SPEC_FILES[@]}"; do
+    if [ ! -f "$spec" ]; then
+        echo "ERROR: additional spec file not found: $spec" >&2
+        status=1
+        continue
+    fi
+    check_spec "$spec"
+done
+
+check_duplicate_active_ids
+check_retired_registry
+check_previous_registry
+
+if [ "$status" -eq 0 ]; then
+    echo "Target-draft policy valid: $target"
+fi
+
+exit "$status"

--- a/validate-registration.sh
+++ b/validate-registration.sh
@@ -2,18 +2,20 @@
 # validate-registration.sh - Validate implementations.json registration changes.
 #
 # Runs the default checks for a PR that adds/removes/edits a client or relay
-# registration. Usable locally and in CI. Three checks:
+# registration. Usable locally and in CI. Four checks:
 #
 #   1. Schema     - implementations.json validates against implementations.schema.json
-#   2. Test plan  - for each changed implementation, show the pairs + negotiated
+#   2. Test specs - canonical specs match implementations.json.current_target and
+#                   retirement history remains append-only when present in --base
+#   3. Test plan  - for each changed implementation, show the pairs + negotiated
 #                   draft versions that WOULD be tested (run-interop-tests.sh --dry-run)
-#   3. Image      - the Docker image(s) the changed impl registers actually exist
+#   4. Image      - the Docker image(s) the changed impl registers actually exist
 #                   (soft warning: a private/unpullable image cannot be checked on
 #                   a fork PR, so it must not hard-fail the gate)
 #
-# Only the schema check is a hard gate. The plan is informational; image problems
-# are warnings. Interop pass/fail is NOT evaluated here — that is the maintainer-
-# gated live run.
+# The schema and test-spec checks are hard gates. The plan is informational;
+# image problems are warnings. Interop pass/fail is NOT evaluated here — that is
+# the maintainer-gated live run.
 #
 # Usage:
 #   ./validate-registration.sh [--base <ref>] [--impl <name>] [--summary <file>]
@@ -23,14 +25,15 @@
 #   --summary <file> Append the markdown report here (default: $GITHUB_STEP_SUMMARY, else stdout)
 #
 # Exit codes:
-#   0 - Schema valid (warnings may be present)
-#   1 - Schema invalid, or a usage/environment error
+#   0 - Schema and test-spec policy valid (warnings may be present)
+#   1 - A hard gate failed, or a usage/environment error
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG_FILE="$SCRIPT_DIR/implementations.json"
 SCHEMA_FILE="$SCRIPT_DIR/implementations.schema.json"
+TARGET_DRAFT_VALIDATOR="$SCRIPT_DIR/scripts/validate-target-draft.sh"
 
 BASE_REF="origin/main"
 EXPLICIT_IMPL=""
@@ -50,11 +53,17 @@ done
 
 # Markdown report accumulates in a temp file, then is appended to the target.
 REPORT="$(mktemp "${TMPDIR:-/tmp}/validate-registration.XXXXXX")"
-trap 'rm -f "$REPORT"' EXIT
+PREVIOUS_RETIRED_FILE=""
+cleanup() {
+    rm -f "$REPORT"
+    [ -z "$PREVIOUS_RETIRED_FILE" ] || rm -f "$PREVIOUS_RETIRED_FILE"
+}
+trap cleanup EXIT
 md() { printf '%s\n' "$1" >> "$REPORT"; }
 
 # Track the worst outcome for the final exit code and headline.
 SCHEMA_OK=true
+TARGET_DRAFT_OK=true
 WARNINGS=0
 
 #############################################################################
@@ -63,6 +72,7 @@ WARNINGS=0
 command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required" >&2; exit 1; }
 [ -f "$CONFIG_FILE" ] || { echo "ERROR: $CONFIG_FILE not found" >&2; exit 1; }
 [ -f "$SCHEMA_FILE" ] || { echo "ERROR: $SCHEMA_FILE not found" >&2; exit 1; }
+[ -x "$TARGET_DRAFT_VALIDATOR" ] || { echo "ERROR: $TARGET_DRAFT_VALIDATOR not found or not executable" >&2; exit 1; }
 
 if ! jq empty "$CONFIG_FILE" 2>/dev/null; then
     md "## Registration validation"
@@ -100,7 +110,19 @@ else
 fi
 
 #############################################################################
-# 2. Determine changed implementations
+# 2. Target-draft test-spec validation (hard gate)
+#############################################################################
+target_draft_error=""
+target_draft_args=()
+if git cat-file -e "$BASE_REF:docs/tests/retired-test-identifiers.json" 2>/dev/null; then
+    PREVIOUS_RETIRED_FILE="$(mktemp "${TMPDIR:-/tmp}/previous-retired-test-identifiers.XXXXXX")"
+    git show "$BASE_REF:docs/tests/retired-test-identifiers.json" > "$PREVIOUS_RETIRED_FILE"
+    target_draft_args=(--previous-retired "$PREVIOUS_RETIRED_FILE")
+fi
+target_draft_error="$("$TARGET_DRAFT_VALIDATOR" "${target_draft_args[@]}" 2>&1)" || TARGET_DRAFT_OK=false
+
+#############################################################################
+# 3. Determine changed implementations
 #############################################################################
 CHANGED=()
 REMOVED=()
@@ -156,6 +178,18 @@ else
     md ""
     md '```'
     md "${schema_error:-validation failed}"
+    md '```'
+fi
+md ""
+
+# --- Target-draft test specs ---
+if [ "$TARGET_DRAFT_OK" = true ]; then
+    md "**Test specs:** ✅ $target_draft_error"
+else
+    md "**Test specs:** ❌ target-draft policy invalid"
+    md ""
+    md '```'
+    md "${target_draft_error:-validation failed}"
     md '```'
 fi
 md ""
@@ -220,14 +254,14 @@ fi
 
 # --- Footer / headline ---
 md "---"
-if [ "$SCHEMA_OK" = true ]; then
+if [ "$SCHEMA_OK" = true ] && [ "$TARGET_DRAFT_OK" = true ]; then
     if [ "$WARNINGS" -gt 0 ]; then
         md "✅ Schema valid · ⚠️ $WARNINGS image warning(s) (non-blocking)"
     else
         md "✅ All checks passed."
     fi
 else
-    md "❌ Schema invalid — fix the errors above."
+    md "❌ Hard validation failed — fix the errors above."
 fi
 
 #############################################################################
@@ -238,4 +272,4 @@ if [ -n "$SUMMARY_OUT" ] && [ "$SUMMARY_OUT" != "/dev/stdout" ]; then
     cat "$REPORT" >> "$SUMMARY_OUT"
 fi
 
-[ "$SCHEMA_OK" = true ]
+[ "$SCHEMA_OK" = true ] && [ "$TARGET_DRAFT_OK" = true ]

--- a/validate-registration.sh
+++ b/validate-registration.sh
@@ -5,8 +5,8 @@
 # registration. Usable locally and in CI. Four checks:
 #
 #   1. Schema     - implementations.json validates against implementations.schema.json
-#   2. Test specs - canonical specs match implementations.json.current_target and
-#                   retirement history remains append-only when present in --base
+#   2. Test specs - canonical specs match implementations.json.current_target,
+#                   removed IDs are retired, and retirement history is append-only
 #   3. Test plan  - for each changed implementation, show the pairs + negotiated
 #                   draft versions that WOULD be tested (run-interop-tests.sh --dry-run)
 #   4. Image      - the Docker image(s) the changed impl registers actually exist
@@ -54,9 +54,11 @@ done
 # Markdown report accumulates in a temp file, then is appended to the target.
 REPORT="$(mktemp "${TMPDIR:-/tmp}/validate-registration.XXXXXX")"
 PREVIOUS_RETIRED_FILE=""
+PREVIOUS_SPEC_FILE=""
 cleanup() {
     rm -f "$REPORT"
     [ -z "$PREVIOUS_RETIRED_FILE" ] || rm -f "$PREVIOUS_RETIRED_FILE"
+    [ -z "$PREVIOUS_SPEC_FILE" ] || rm -f "$PREVIOUS_SPEC_FILE"
 }
 trap cleanup EXIT
 md() { printf '%s\n' "$1" >> "$REPORT"; }
@@ -117,7 +119,12 @@ target_draft_args=()
 if git cat-file -e "$BASE_REF:docs/tests/retired-test-identifiers.json" 2>/dev/null; then
     PREVIOUS_RETIRED_FILE="$(mktemp "${TMPDIR:-/tmp}/previous-retired-test-identifiers.XXXXXX")"
     git show "$BASE_REF:docs/tests/retired-test-identifiers.json" > "$PREVIOUS_RETIRED_FILE"
-    target_draft_args=(--previous-retired "$PREVIOUS_RETIRED_FILE")
+    target_draft_args+=(--previous-retired "$PREVIOUS_RETIRED_FILE")
+fi
+if git cat-file -e "$BASE_REF:docs/tests/TEST-CASES.md" 2>/dev/null; then
+    PREVIOUS_SPEC_FILE="$(mktemp "${TMPDIR:-/tmp}/previous-test-cases.XXXXXX")"
+    git show "$BASE_REF:docs/tests/TEST-CASES.md" > "$PREVIOUS_SPEC_FILE"
+    target_draft_args+=(--previous-spec "$PREVIOUS_SPEC_FILE")
 fi
 target_draft_error="$("$TARGET_DRAFT_VALIDATOR" "${target_draft_args[@]}" 2>&1)" || TARGET_DRAFT_OK=false
 


### PR DESCRIPTION
## Summary

- define `publish-without-subscriber` and `publish-to-pending-subscription` for the current target draft
- specify Forward State handling, exact Object identity and payload, PUBLISH_DONE Stream Count, and request-stream FIN
- define stable semantic test IDs and retirement records for behavior changes
- validate target declarations, protocol references, test headings, and append-only retirement history

## Test behavior

`publish-without-subscriber` exercises a direct PUBLISH lifecycle with no downstream subscriber and honors the Forward State returned by the relay.

`publish-to-pending-subscription` starts the exact-track SUBSCRIBE first, connects the publisher, delivers one Object after forwarding is enabled, and verifies PUBLISH_DONE and stream completion even when control and data arrive in different orders.

Each run uses a fresh 128-bit hexadecimal Track Name to avoid stale or concurrent track collisions.

## Validation

- `./scripts/validate-target-draft.sh`
- `./scripts/test-validate-target-draft.sh`
- JSON and shell syntax checks
- `git diff --check`

## Limitations

This change defines the tests and identifier policy. It does not add a client implementation for the two tests.