### PR TITLE
Update moq-rs entries: main branch is now draft-16 only

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -231,14 +231,37 @@
       "organization": "Cloudflare",
       "repository": "https://github.com/cloudflare/moq-rs",
       "draft_versions": [
-        "draft-14"
+        "draft-16"
       ],
-      "notes": "Rust implementation. Test client reference implementation.",
+      "notes": "Rust implementation. Test client reference implementation. Main branch now supports draft-16 (merged via https://github.com/cloudflare/moq-rs/pull/170).",
       "roles": {
         "relay": {
           "docker": {
             "image": "ghcr.io/englishm/moq-interop-runner-moq-relay-ietf:latest",
-            "notes": "Pre-built on GHCR. To build from source: ./builds/moq-rs/build.sh && docker tag moq-relay-ietf:latest ghcr.io/englishm/moq-interop-runner-moq-relay-ietf:latest"
+            "notes": "Pre-built on GHCR. To build from source (main branch, draft-16): ./builds/moq-rs/build.sh && docker tag moq-relay-ietf:latest ghcr.io/englishm/moq-interop-runner-moq-relay-ietf:latest"
+          }
+        },
+        "client": {
+          "docker": {
+            "image": "ghcr.io/englishm/moq-interop-runner-moq-test-client:latest",
+            "notes": "Pre-built on GHCR. To build from source (main branch, draft-16): ./builds/moq-rs/build.sh && docker tag moq-test-client:latest ghcr.io/englishm/moq-interop-runner-moq-test-client:latest"
+          }
+        }
+      }
+    },
+    "moq-rs-draft-14": {
+      "name": "moq-rs (draft-14)",
+      "organization": "Cloudflare",
+      "repository": "https://github.com/cloudflare/moq-rs",
+      "draft_versions": [
+        "draft-14"
+      ],
+      "notes": "Rust implementation. Draft-14 support maintained on the draft-ietf-moq-transport-14 branch (https://github.com/cloudflare/moq-rs/tree/draft-ietf-moq-transport-14).",
+      "roles": {
+        "relay": {
+          "docker": {
+            "image": "ghcr.io/englishm/moq-interop-runner-moq-relay-ietf-draft-16:latest",
+            "notes": "Pre-built on GHCR. To build from source: ./builds/moq-rs/build.sh --repo https://github.com/cloudflare/moq-rs --ref draft-ietf-moq-transport-14 --target relay && docker tag moq-relay-ietf:latest ghcr.io/englishm/moq-interop-runner-moq-relay-ietf-draft-16:latest"
           },
           "remote": [
             {
@@ -255,43 +278,8 @@
         },
         "client": {
           "docker": {
-            "image": "ghcr.io/englishm/moq-interop-runner-moq-test-client:latest",
-            "notes": "Pre-built on GHCR. To build from source: ./builds/moq-rs/build.sh && docker tag moq-test-client:latest ghcr.io/englishm/moq-interop-runner-moq-test-client:latest"
-          }
-        }
-      }
-    },
-    "moq-rs-draft-16": {
-      "name": "moq-rs (draft-16)",
-      "organization": "Cloudflare",
-      "repository": "https://github.com/itzmanish/moq-rs",
-      "draft_versions": [
-        "draft-16"
-      ],
-      "notes": "Rust implementation. Draft-16 branch from itzmanish (Manish Pandit), based on https://github.com/cloudflare/moq-rs/pull/131.",
-      "roles": {
-        "relay": {
-          "docker": {
-            "image": "ghcr.io/englishm/moq-interop-runner-moq-relay-ietf-draft-16:latest",
-            "notes": "Pre-built on GHCR. To build from source: ./builds/moq-rs/build.sh --repo https://github.com/itzmanish/moq-rs --ref draft-16 --target relay && docker tag moq-relay-ietf:latest ghcr.io/englishm/moq-interop-runner-moq-relay-ietf-draft-16:latest"
-          },
-          "remote": [
-            {
-              "url": "moqt://draft-16-manish.cloudflare.mediaoverquic.com:443",
-              "transport": "quic",
-              "notes": "Raw QUIC endpoint"
-            },
-            {
-              "url": "https://draft-16-manish.cloudflare.mediaoverquic.com:443/moq",
-              "transport": "webtransport",
-              "notes": "WebTransport endpoint"
-            }
-          ]
-        },
-        "client": {
-          "docker": {
             "image": "ghcr.io/englishm/moq-interop-runner-moq-test-client-draft-16:latest",
-            "notes": "Pre-built on GHCR. To build from source: ./builds/moq-rs/build.sh --repo https://github.com/itzmanish/moq-rs --ref draft-16 --target client && docker tag moq-test-client:latest ghcr.io/englishm/moq-interop-runner-moq-test-client-draft-16:latest"
+            "notes": "Pre-built on GHCR. To build from source: ./builds/moq-rs/build.sh --repo https://github.com/cloudflare/moq-rs --ref draft-ietf-moq-transport-14 --target client && docker tag moq-test-client:latest ghcr.io/englishm/moq-interop-runner-moq-test-client-draft-16:latest"
           }
         }
       }


### PR DESCRIPTION
## Summary

cloudflare/moq-rs main branch now supports draft-16, merged via https://github.com/cloudflare/moq-rs/pull/170.

### Changes

- **`moq-rs`**: Updated `draft_versions` from `["draft-14"]` to `["draft-16"]`. Notes updated to reference the merged PR. Remote endpoints removed (no public draft-16 remote is ready yet — docker only for now). Docker build notes clarified to reflect main branch = draft-16.

- **`moq-rs-draft-16` → `moq-rs-draft-14`**: Replaced the old entry (which pointed at the itzmanish fork) with a new `moq-rs-draft-14` entry pointing at the official `cloudflare/moq-rs` repo, `draft-ietf-moq-transport-14` branch. The remote endpoints previously on the `moq-rs` entry (`draft-14.cloudflare.mediaoverquic.com`) are moved here. Old `draft-16-manish.cloudflare.mediaoverquic.com` endpoints removed.

- **`moq-rs-draft-18`**: Unchanged.