### PR TITLE
Add "Rebuild All Images" workflow dispatch button (refs #96)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -9,7 +9,7 @@ on:
         type: choice
         options:
           - moq-rs
-          - moq-rs-draft-16
+          - moq-rs-draft-14
           - moxygen
           - moq-dev-rs
           - moq-dev-rs-client
@@ -23,6 +23,19 @@ on:
           - moq-rs-draft-18-relay
           - moq-rs-draft-18-client
           - moq-go
+          - moqtopus-client
+      ref:
+        description: 'Git ref for source builds (branch/tag/commit). Ignored for adapters.'
+        required: false
+        type: string
+  # Called by rebuild-all-images.yml (and any future scheduled workflows).
+  # workflow_call uses type: string for inputs; type: choice is workflow_dispatch-only.
+  workflow_call:
+    inputs:
+      implementation:
+        description: 'Implementation to build'
+        required: true
+        type: string
       ref:
         description: 'Git ref for source builds (branch/tag/commit). Ignored for adapters.'
         required: false
@@ -55,13 +68,13 @@ jobs:
               echo "build_command=./builds/moq-rs/build.sh --ref $REF" >> "$GITHUB_OUTPUT"
               echo 'images=[{"local":"moq-relay-ietf:latest","ghcr":"ghcr.io/englishm/moq-interop-runner-moq-relay-ietf"},{"local":"moq-test-client:latest","ghcr":"ghcr.io/englishm/moq-interop-runner-moq-test-client"}]' >> "$GITHUB_OUTPUT"
               ;;
-            moq-rs-draft-16)
+            moq-rs-draft-14)
               REF="${{ inputs.ref }}"
-              REF="${REF:-me/draft-16-interop}"
+              REF="${REF:-draft-ietf-moq-transport-14}"
               echo "build_type=build" >> "$GITHUB_OUTPUT"
               echo "ref=$REF" >> "$GITHUB_OUTPUT"
-              echo "build_command=./builds/moq-rs/build.sh --repo https://github.com/englishm-cloudflare/moq-rs-1 --ref $REF" >> "$GITHUB_OUTPUT"
-              echo 'images=[{"local":"moq-relay-ietf:latest","ghcr":"ghcr.io/englishm/moq-interop-runner-moq-relay-ietf-draft-16"},{"local":"moq-test-client:latest","ghcr":"ghcr.io/englishm/moq-interop-runner-moq-test-client-draft-16"}]' >> "$GITHUB_OUTPUT"
+              echo "build_command=./builds/moq-rs/build.sh --repo https://github.com/cloudflare/moq-rs --ref $REF" >> "$GITHUB_OUTPUT"
+              echo 'images=[{"local":"moq-relay-ietf:latest","ghcr":"ghcr.io/englishm/moq-interop-runner-moq-relay-ietf-draft-14"},{"local":"moq-test-client:latest","ghcr":"ghcr.io/englishm/moq-interop-runner-moq-test-client-draft-14"}]' >> "$GITHUB_OUTPUT"
               ;;
             quiche-moq)
               REF="${{ inputs.ref }}"
@@ -155,6 +168,14 @@ jobs:
               echo "build_command=./builds/moq-go/build.sh --ref $REF" >> "$GITHUB_OUTPUT"
               echo 'images=[{"local":"moq-go-relay:latest","ghcr":"ghcr.io/englishm/moq-interop-runner-moq-go-relay"},{"local":"moq-go-client:latest","ghcr":"ghcr.io/englishm/moq-interop-runner-moq-go-client"}]' >> "$GITHUB_OUTPUT"
               ;;
+            moqtopus-client)
+              REF="${{ inputs.ref }}"
+              REF="${REF:-main}"
+              echo "build_type=build" >> "$GITHUB_OUTPUT"
+              echo "ref=$REF" >> "$GITHUB_OUTPUT"
+              echo "build_command=./builds/moqtopus/build.sh --ref $REF --target client" >> "$GITHUB_OUTPUT"
+              echo 'images=[{"local":"moqtopus-interop-client:latest","ghcr":"ghcr.io/englishm/moq-interop-runner-moqtopus-interop-client"}]' >> "$GITHUB_OUTPUT"
+              ;;
             *)
               echo "::error::Unknown implementation: $IMPL"
               exit 1
@@ -173,13 +194,15 @@ jobs:
           # Extract source commit from the build provenance
           IMPL_DIR=""
           case "${{ inputs.implementation }}" in
-            moq-rs|moq-rs-draft-16) IMPL_DIR="builds/moq-rs" ;;
+            moq-rs|moq-rs-draft-14) IMPL_DIR="builds/moq-rs" ;;
             quiche-moq)             IMPL_DIR="builds/quiche-moq" ;;
             moq-dev-rs-client)      IMPL_DIR="builds/moq-dev-rs" ;;
             moq-dev-js-client)      IMPL_DIR="builds/moq-dev-js" ;;
             xquic-relay|xquic-client|xquic-draft-18-client) IMPL_DIR="builds/xquic" ;;
             imquic-relay|imquic-client) IMPL_DIR="builds/imquic" ;;
             moq-rs-draft-18-relay|moq-rs-draft-18-client) IMPL_DIR="builds/moq-rs-draft-18" ;;
+            moq-go)                                       IMPL_DIR="builds/moq-go" ;;
+            moqtopus-client)                              IMPL_DIR="builds/moqtopus" ;;
           esac
 
           if [[ -f "$IMPL_DIR/.last-build.json" ]]; then

--- a/.github/workflows/interop-report.yml
+++ b/.github/workflows/interop-report.yml
@@ -82,12 +82,12 @@ jobs:
           docker tag moq-relay-ietf:latest ghcr.io/englishm/moq-interop-runner-moq-relay-ietf:latest
           docker tag moq-test-client:latest ghcr.io/englishm/moq-interop-runner-moq-test-client:latest
 
-          # Build moq-rs-draft-16
+          # Build moq-rs-draft-14 (cloudflare/moq-rs, draft-ietf-moq-transport-14 branch)
           ./builds/moq-rs/build.sh \
-            --repo https://github.com/englishm-cloudflare/moq-rs-1 \
-            --ref me/draft-16-interop
-          docker tag moq-relay-ietf:latest ghcr.io/englishm/moq-interop-runner-moq-relay-ietf-draft-16:latest
-          docker tag moq-test-client:latest ghcr.io/englishm/moq-interop-runner-moq-test-client-draft-16:latest
+            --repo https://github.com/cloudflare/moq-rs \
+            --ref draft-ietf-moq-transport-14
+          docker tag moq-relay-ietf:latest ghcr.io/englishm/moq-interop-runner-moq-relay-ietf-draft-14:latest
+          docker tag moq-test-client:latest ghcr.io/englishm/moq-interop-runner-moq-test-client-draft-14:latest
 
       - name: Build adapters
         working-directory: main

--- a/.github/workflows/rebuild-all-images.yml
+++ b/.github/workflows/rebuild-all-images.yml
@@ -1,0 +1,69 @@
+# Rebuild All Docker Images
+#
+# Provides a manual "Rebuild All" button in the GitHub Actions tab, and is
+# structured so that enabling nightly rebuilds requires only uncommenting the
+# schedule block below (phase-2 follow-up PR, refs #96).
+#
+# Two-phase approach:
+#   Phase 1 (this PR): workflow_dispatch only. Operators trigger a full rebuild
+#     on demand — useful before major interop events or when upstream deps drift.
+#   Phase 2 (follow-up PR): Uncomment the schedule block. Nightly rebuilds keep
+#     every GHCR image fresh without operator intervention.
+#
+# Build time vs. freshness tradeoff is documented in issue #96.
+
+name: Rebuild All Docker Images
+
+on:
+  workflow_dispatch:
+  # Uncomment to enable nightly rebuilds (see issue #96 follow-up PR):
+  #  schedule:
+  #    - cron: '0 22 * * *'  # Nightly at 10pm UTC — images ready before the midnight interop run
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    strategy:
+      max-parallel: 4
+      matrix:
+        include:
+          - implementation: moq-rs
+            ref: ''
+          - implementation: moq-rs-draft-14
+            ref: ''
+          - implementation: moxygen
+            ref: ''
+          - implementation: moq-dev-rs
+            ref: ''
+          - implementation: moq-dev-rs-client
+            ref: ''
+          - implementation: moq-dev-js-client
+            ref: ''
+          - implementation: quiche-moq
+            ref: ''
+          - implementation: xquic-relay
+            ref: ''
+          - implementation: xquic-client
+            ref: ''
+          - implementation: xquic-draft-18-client
+            ref: ''
+          - implementation: imquic-relay
+            ref: ''
+          - implementation: imquic-client
+            ref: ''
+          - implementation: moq-rs-draft-18-relay
+            ref: ''
+          - implementation: moq-rs-draft-18-client
+            ref: ''
+          - implementation: moq-go
+            ref: ''
+          - implementation: moqtopus-client
+            ref: ''
+    uses: ./.github/workflows/build-images.yml
+    with:
+      implementation: ${{ matrix.implementation }}
+      ref: ${{ matrix.ref }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds a manual "Rebuild All Docker Images" `workflow_dispatch` button in the Actions tab. Makes `build-images.yml` a reusable `workflow_call` target so the button fans out across every implementation via a 16-impl matrix. Also picks up the `moq-rs-draft-14` rename from PR #107 and adds `moqtopus-client` (PR #106).

Refs: #96, #107, #106

---

## Two-PR strategy

**Phase 1 (this PR):** Manual dispatch only — one button in the Actions tab triggers a 16-impl parallel matrix build (max 4 at a time).

**Phase 2 (follow-up PR):** Uncomment the `schedule:` block in `rebuild-all-images.yml` — pre-written as `0 22 * * *` (10 PM UTC, images ready before the midnight interop run).

---

## Changes

### `build-images.yml`
- Add `workflow_call:` trigger (`type: string` inputs; `type: choice` is `workflow_dispatch`-only).
- Rename `moq-rs-draft-16` → `moq-rs-draft-14`: repo `cloudflare/moq-rs`, ref `draft-ietf-moq-transport-14`, GHCR tags `-draft-14`.
- Add `moqtopus-client`: `./builds/moqtopus/build.sh --ref main --target client` → `ghcr.io/englishm/moq-interop-runner-moqtopus-interop-client`.
- Fix pre-existing gap: `moq-go` was missing from source-commit case (so moq-go builds never received commit-SHA tags).

### `rebuild-all-images.yml` (new file)
Matrix job calling `build-images.yml` for all 16 implementations. `max-parallel: 4`. `schedule:` pre-written but commented out for Phase 2.

### `interop-report.yml`
Update hardcoded `build_from_source` step: `moq-rs-draft-16` → `moq-rs-draft-14`.

---

## Note: workflow files need a manual push

The automation token lacks the GitHub `workflows` permission, so `.github/workflows/` changes could not be pushed to the branch. The README commit above is a placeholder to allow PR creation; the real changes are the three workflow files in the diff below.

The commit is ready locally at `5929b84a` on the `rebuild-all-images` branch in `/workspace/moq-interop-runner`. To complete the branch, push with a PAT that has the `workflow` scope:

```bash
git -C /workspace/moq-interop-runner push --force \
  "https://<YOUR-GITHUB-PAT>@github.com:443/englishm/moq-interop-runner.git" \
  rebuild-all-images
```

---

## Full workflow diff

```diff
diff --git a/.github/workflows/build-images.yml b/.github/workflows/build-images.yml
index 252484fe..839f29ca 100644
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -9,7 +9,7 @@ on:
         type: choice
         options:
           - moq-rs
-          - moq-rs-draft-16
+          - moq-rs-draft-14
           - moxygen
           - moq-dev-rs
           - moq-dev-rs-client
@@ -23,6 +23,19 @@ on:
           - moq-rs-draft-18-relay
           - moq-rs-draft-18-client
           - moq-go
+          - moqtopus-client
+      ref:
+        description: 'Git ref for source builds (branch/tag/commit). Ignored for adapters.'
+        required: false
+        type: string
+  # Called by rebuild-all-images.yml (and any future scheduled workflows).
+  # workflow_call uses type: string for inputs; type: choice is workflow_dispatch-only.
+  workflow_call:
+    inputs:
+      implementation:
+        description: 'Implementation to build'
+        required: true
+        type: string
       ref:
         description: 'Git ref for source builds (branch/tag/commit). Ignored for adapters.'
         required: false
@@ -55,13 +68,13 @@ jobs:
               echo "build_command=./builds/moq-rs/build.sh --ref $REF" >> "$GITHUB_OUTPUT"
               echo 'images=[{"local":"moq-relay-ietf:latest","ghcr":"ghcr.io/englishm/moq-interop-runner-moq-relay-ietf"},{"local":"moq-test-client:latest","ghcr":"ghcr.io/englishm/moq-interop-runner-moq-test-client"}]' >> "$GITHUB_OUTPUT"
               ;;
-            moq-rs-draft-16)
+            moq-rs-draft-14)
               REF="${{ inputs.ref }}"
-              REF="${REF:-me/draft-16-interop}"
+              REF="${REF:-draft-ietf-moq-transport-14}"
               echo "build_type=build" >> "$GITHUB_OUTPUT"
               echo "ref=$REF" >> "$GITHUB_OUTPUT"
-              echo "build_command=./builds/moq-rs/build.sh --repo https://github.com/englishm-cloudflare/moq-rs-1 --ref $REF" >> "$GITHUB_OUTPUT"
-              echo 'images=[{"local":"moq-relay-ietf:latest","ghcr":"ghcr.io/englishm/moq-interop-runner-moq-relay-ietf-draft-16"},{"local":"moq-test-client:latest","ghcr":"ghcr.io/englishm/moq-interop-runner-moq-test-client-draft-16"}]' >> "$GITHUB_OUTPUT"
+              echo "build_command=./builds/moq-rs/build.sh --repo https://github.com/cloudflare/moq-rs --ref $REF" >> "$GITHUB_OUTPUT"
+              echo 'images=[{"local":"moq-relay-ietf:latest","ghcr":"ghcr.io/englishm/moq-interop-runner-moq-relay-ietf-draft-14"},{"local":"moq-test-client:latest","ghcr":"ghcr.io/englishm/moq-interop-runner-moq-test-client-draft-14"}]' >> "$GITHUB_OUTPUT"
               ;;
             quiche-moq)
               REF="${{ inputs.ref }}"
@@ -155,6 +168,14 @@ jobs:
               echo "build_command=./builds/moq-go/build.sh --ref $REF" >> "$GITHUB_OUTPUT"
               echo 'images=[{"local":"moq-go-relay:latest","ghcr":"ghcr.io/englishm/moq-interop-runner-moq-go-relay"},{"local":"moq-go-client:latest","ghcr":"ghcr.io/englishm/moq-interop-runner-moq-go-client"}]' >> "$GITHUB_OUTPUT"
               ;;
+            moqtopus-client)
+              REF="${{ inputs.ref }}"
+              REF="${REF:-main}"
+              echo "build_type=build" >> "$GITHUB_OUTPUT"
+              echo "ref=$REF" >> "$GITHUB_OUTPUT"
+              echo "build_command=./builds/moqtopus/build.sh --ref $REF --target client" >> "$GITHUB_OUTPUT"
+              echo 'images=[{"local":"moqtopus-interop-client:latest","ghcr":"ghcr.io/englishm/moq-interop-runner-moqtopus-interop-client"}]' >> "$GITHUB_OUTPUT"
+              ;;
             *)
               echo "::error::Unknown implementation: $IMPL"
               exit 1
@@ -173,13 +194,15 @@ jobs:
           # Extract source commit from the build provenance
           IMPL_DIR=""
           case "${{ inputs.implementation }}" in
-            moq-rs|moq-rs-draft-16) IMPL_DIR="builds/moq-rs" ;;
+            moq-rs|moq-rs-draft-14) IMPL_DIR="builds/moq-rs" ;;
             quiche-moq)             IMPL_DIR="builds/quiche-moq" ;;
             moq-dev-rs-client)      IMPL_DIR="builds/moq-dev-rs" ;;
             moq-dev-js-client)      IMPL_DIR="builds/moq-dev-js" ;;
             xquic-relay|xquic-client|xquic-draft-18-client) IMPL_DIR="builds/xquic" ;;
             imquic-relay|imquic-client) IMPL_DIR="builds/imquic" ;;
             moq-rs-draft-18-relay|moq-rs-draft-18-client) IMPL_DIR="builds/moq-rs-draft-18" ;;
+            moq-go)                                       IMPL_DIR="builds/moq-go" ;;
+            moqtopus-client)                              IMPL_DIR="builds/moqtopus" ;;
           esac
 
           if [[ -f "$IMPL_DIR/.last-build.json" ]]; then
diff --git a/.github/workflows/interop-report.yml b/.github/workflows/interop-report.yml
index 5b79e136..7bbcfcea 100644
--- a/.github/workflows/interop-report.yml
+++ b/.github/workflows/interop-report.yml
@@ -82,12 +82,12 @@ jobs:
           docker tag moq-relay-ietf:latest ghcr.io/englishm/moq-interop-runner-moq-relay-ietf:latest
           docker tag moq-test-client:latest ghcr.io/englishm/moq-interop-runner-moq-test-client:latest
 
-          # Build moq-rs-draft-16
+          # Build moq-rs-draft-14 (cloudflare/moq-rs, draft-ietf-moq-transport-14 branch)
           ./builds/moq-rs/build.sh \
-            --repo https://github.com/englishm-cloudflare/moq-rs-1 \
-            --ref me/draft-16-interop
-          docker tag moq-relay-ietf:latest ghcr.io/englishm/moq-interop-runner-moq-relay-ietf-draft-16:latest
-          docker tag moq-test-client:latest ghcr.io/englishm/moq-interop-runner-moq-test-client-draft-16:latest
+            --repo https://github.com/cloudflare/moq-rs \
+            --ref draft-ietf-moq-transport-14
+          docker tag moq-relay-ietf:latest ghcr.io/englishm/moq-interop-runner-moq-relay-ietf-draft-14:latest
+          docker tag moq-test-client:latest ghcr.io/englishm/moq-interop-runner-moq-test-client-draft-14:latest
 
       - name: Build adapters
         working-directory: main
diff --git a/.github/workflows/rebuild-all-images.yml b/.github/workflows/rebuild-all-images.yml
new file mode 100644
index 00000000..e8b431d3
--- /dev/null
+++ b/.github/workflows/rebuild-all-images.yml
@@ -0,0 +1,69 @@
+# Rebuild All Docker Images
+#
+# Provides a manual "Rebuild All" button in the GitHub Actions tab, and is
+# structured so that enabling nightly rebuilds requires only uncommenting the
+# schedule block below (phase-2 follow-up PR, refs #96).
+#
+# Two-phase approach:
+#   Phase 1 (this PR): workflow_dispatch only. Operators trigger a full rebuild
+#     on demand — useful before major interop events or when upstream deps drift.
+#   Phase 2 (follow-up PR): Uncomment the schedule block. Nightly rebuilds keep
+#     every GHCR image fresh without operator intervention.
+#
+# Build time vs. freshness tradeoff is documented in issue #96.
+
+name: Rebuild All Docker Images
+
+on:
+  workflow_dispatch:
+  # Uncomment to enable nightly rebuilds (see issue #96 follow-up PR):
+  #  schedule:
+  #    - cron: '0 22 * * *'  # Nightly at 10pm UTC — images ready before the midnight interop run
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    strategy:
+      max-parallel: 4
+      matrix:
+        include:
+          - implementation: moq-rs
+            ref: ''
+          - implementation: moq-rs-draft-14
+            ref: ''
+          - implementation: moxygen
+            ref: ''
+          - implementation: moq-dev-rs
+            ref: ''
+          - implementation: moq-dev-rs-client
+            ref: ''
+          - implementation: moq-dev-js-client
+            ref: ''
+          - implementation: quiche-moq
+            ref: ''
+          - implementation: xquic-relay
+            ref: ''
+          - implementation: xquic-client
+            ref: ''
+          - implementation: xquic-draft-18-client
+            ref: ''
+          - implementation: imquic-relay
+            ref: ''
+          - implementation: imquic-client
+            ref: ''
+          - implementation: moq-rs-draft-18-relay
+            ref: ''
+          - implementation: moq-rs-draft-18-client
+            ref: ''
+          - implementation: moq-go
+            ref: ''
+          - implementation: moqtopus-client
+            ref: ''
+    uses: ./.github/workflows/build-images.yml
+    with:
+      implementation: ${{ matrix.implementation }}
+      ref: ${{ matrix.ref }}
+    secrets: inherit

```