### PR TITLE
feat(builds): register kvick relay

### DIFF
--- a/builds/kvick/Dockerfile.relay
+++ b/builds/kvick/Dockerfile.relay
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+
+FROM rust:1.93-bookworm AS builder
+
+WORKDIR /build
+COPY . .
+RUN cargo build --locked --release -p moq-relay --features bin,draft-18
+
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    iproute2 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=builder /build/target/release/moq-relay /app/moq-relay
+COPY .moq-interop-kvick-entrypoint.sh /app/run_endpoint.sh
+RUN chmod 755 /app/run_endpoint.sh \
+    && useradd -r -u 1000 -g nogroup moq
+
+ENV MOQT_ROLE=relay
+ENV MOQT_PORT=4443
+
+EXPOSE 4443/udp
+
+HEALTHCHECK --interval=2s --timeout=5s --start-period=5s --retries=10 \
+    CMD sh -c 'ss -uln | grep -q ":${MOQT_PORT:-4443}" || exit 1'
+
+USER moq
+ENTRYPOINT ["/app/run_endpoint.sh"]

--- a/builds/kvick/Dockerfile.relay.dockerignore
+++ b/builds/kvick/Dockerfile.relay.dockerignore
@@ -1,0 +1,4 @@
+.git
+target
+kvick-web/node_modules
+**/*.log

--- a/builds/kvick/README.md
+++ b/builds/kvick/README.md
@@ -1,0 +1,24 @@
+# kvick relay build
+
+Build the kvick relay image from current upstream `main`:
+
+```bash
+./builds/kvick/build.sh --target relay
+```
+
+For local development, build a checkout or worktree directly:
+
+```bash
+./builds/kvick/build.sh --local /absolute/path/to/kvick-ai --target relay
+```
+
+The resulting image is `kvick-relay:latest`. Its entrypoint follows the runner
+certificate and port conventions and configures a catch-all origin route. It
+sets `unknown_track_subscribe_grace_ms = 750` as the #3827 interoperability
+experiment value; kvick's shipped product default remains 2000 ms.
+
+Run the entrypoint contract test without Docker:
+
+```bash
+./builds/kvick/test-entrypoint.sh
+```

--- a/builds/kvick/build.sh
+++ b/builds/kvick/build.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+set -euo pipefail
+
+build_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+runner_root="$(cd "$build_dir/../.." && pwd)"
+sources_dir="$build_dir/.sources"
+repo_url="https://github.com/bergstroem/kvick-ai"
+ref=""
+local_path=""
+target="relay"
+
+usage() {
+    cat <<'EOF'
+Usage: build.sh [--ref REF] [--repo URL] [--local PATH] [--target relay]
+EOF
+}
+
+while (($# > 0)); do
+    case "$1" in
+        --ref) ref="${2:?--ref requires a value}"; shift 2 ;;
+        --repo) repo_url="${2:?--repo requires a value}"; shift 2 ;;
+        --local) local_path="${2:?--local requires a value}"; shift 2 ;;
+        --target) target="${2:?--target requires a value}"; shift 2 ;;
+        --help|-h) usage; exit 0 ;;
+        *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+if [[ -n "$local_path" && -n "$ref" ]]; then
+    echo "--local and --ref are mutually exclusive" >&2
+    exit 2
+fi
+if [[ "$target" != "relay" ]]; then
+    echo "unsupported target: $target" >&2
+    exit 2
+fi
+
+if [[ -n "$local_path" ]]; then
+    source_dir="$(cd "$local_path" && pwd)"
+    source_type="local"
+else
+    ref="${ref:-main}"
+    source_dir="$sources_dir/kvick"
+    source_type="git"
+    mkdir -p "$sources_dir"
+    if [[ -e "$source_dir" && ! -d "$source_dir/.git" ]]; then
+        echo "source path exists but is not the expected clone: $source_dir" >&2
+        exit 2
+    fi
+    if [[ ! -d "$source_dir/.git" ]]; then
+        git clone "$repo_url" "$source_dir"
+    else
+        existing_url="$(git -C "$source_dir" remote get-url origin)"
+        if [[ "$existing_url" != "$repo_url" ]]; then
+            echo "source clone remote differs: $existing_url" >&2
+            exit 2
+        fi
+        git -C "$source_dir" fetch origin
+    fi
+    checkout_ref="$ref"
+    if git -C "$source_dir" show-ref --verify --quiet "refs/remotes/origin/$ref"; then
+        checkout_ref="origin/$ref"
+    fi
+    git -C "$source_dir" checkout --detach "$checkout_ref"
+fi
+
+source_commit="$(git -C "$source_dir" rev-parse HEAD 2>/dev/null || printf unknown)"
+source_dirty=false
+if [[ -n "$(git -C "$source_dir" status --porcelain 2>/dev/null)" ]]; then
+    source_dirty=true
+fi
+
+entrypoint_dest="$source_dir/.moq-interop-kvick-entrypoint.sh"
+if [[ -e "$entrypoint_dest" ]]; then
+    echo "refusing to overwrite $entrypoint_dest" >&2
+    exit 2
+fi
+cleanup() {
+    rm -f "$entrypoint_dest"
+}
+trap cleanup EXIT
+cp "$build_dir/entrypoint-relay.sh" "$entrypoint_dest"
+
+docker build \
+    -f "$build_dir/Dockerfile.relay" \
+    -t kvick-relay:latest \
+    "$source_dir"
+
+jq -n \
+    --arg implementation kvick \
+    --arg timestamp "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+    --arg runner_commit "$(git -C "$runner_root" rev-parse HEAD 2>/dev/null || printf unknown)" \
+    --arg source_type "$source_type" \
+    --arg repository "$repo_url" \
+    --arg ref "${ref:-local}" \
+    --arg local_path "${local_path:-}" \
+    --arg commit "$source_commit" \
+    --argjson dirty "$source_dirty" \
+    '{
+      implementation: $implementation,
+      timestamp: $timestamp,
+      runner_commit: $runner_commit,
+      source: {
+        type: $source_type,
+        repository: $repository,
+        ref: $ref,
+        local_path: (if $local_path == "" then null else $local_path end),
+        commit: $commit,
+        dirty: $dirty
+      },
+      images: [{target: "relay", image: "kvick-relay:latest"}]
+    }' | tee "$build_dir/.last-build.json"

--- a/builds/kvick/config.json
+++ b/builds/kvick/config.json
@@ -1,0 +1,13 @@
+{
+  "name": "kvick",
+  "description": "Kvick Media-over-QUIC transport and relay stack",
+  "repository": "https://github.com/bergstroem/kvick-ai",
+  "default_ref": "main",
+  "targets": {
+    "relay": {
+      "dockerfile": "Dockerfile.relay",
+      "image_name": "kvick-relay",
+      "context": ".sources/kvick"
+    }
+  }
+}

--- a/builds/kvick/entrypoint-relay.sh
+++ b/builds/kvick/entrypoint-relay.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -euo pipefail
+
+relay_bin="${KVICK_RELAY_BIN:-/app/moq-relay}"
+relay_config="${KVICK_RELAY_CONFIG:-/tmp/kvick-relay.toml}"
+port="${MOQT_PORT:-4443}"
+cert="${MOQT_CERT:-/certs/cert.pem}"
+key="${MOQT_KEY:-/certs/priv.key}"
+
+if [[ ! "$port" =~ ^[0-9]+$ ]] || ((port < 1 || port > 65535)); then
+    echo "invalid MOQT_PORT: $port" >&2
+    exit 2
+fi
+
+cat > "$relay_config" <<EOF
+[server]
+bind = "0.0.0.0:$port"
+max_connections = 64
+
+[tls]
+cert = "$cert"
+key = "$key"
+
+[namespace]
+[namespace.""]
+mode = "origin"
+
+[cache]
+# #3827 experiment lever: preserve delayed publication while beating strict
+# external subscribe-error deadlines. The product default remains 2000 ms.
+unknown_track_subscribe_grace_ms = 750
+
+[auth]
+mode = "allow_all"
+EOF
+
+exec "$relay_bin" --config "$relay_config"

--- a/builds/kvick/test-entrypoint.sh
+++ b/builds/kvick/test-entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+build_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[[ "$(stat -c '%a' "$build_dir/entrypoint-relay.sh")" == "755" ]]
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fake_relay="$tmp_dir/fake-relay"
+config="$tmp_dir/relay.toml"
+args="$tmp_dir/args"
+
+printf '%s\n' '#!/bin/sh' 'printf "%s\\n" "$@" > "$KVICK_TEST_ARGS"' > "$fake_relay"
+chmod +x "$fake_relay"
+
+KVICK_RELAY_BIN="$fake_relay" \
+KVICK_RELAY_CONFIG="$config" \
+KVICK_TEST_ARGS="$args" \
+MOQT_PORT=5443 \
+MOQT_CERT=/certs/test-cert.pem \
+MOQT_KEY=/certs/test-key.pem \
+    "$build_dir/entrypoint-relay.sh"
+
+grep -Fq 'bind = "0.0.0.0:5443"' "$config"
+grep -Fq 'cert = "/certs/test-cert.pem"' "$config"
+grep -Fq 'key = "/certs/test-key.pem"' "$config"
+grep -Fq '[namespace.""]' "$config"
+grep -Fq 'unknown_track_subscribe_grace_ms = 750' "$config"
+grep -Fxq -- '--config' "$args"
+grep -Fxq -- "$config" "$args"

--- a/implementations.json
+++ b/implementations.json
@@ -108,6 +108,31 @@
         }
       }
     },
+    "kvick": {
+      "name": "kvick",
+      "organization": "Kvick",
+      "repository": "https://github.com/bergstroem/kvick-ai",
+      "draft_versions": [
+        "draft-14",
+        "draft-16",
+        "draft-17",
+        "draft-18"
+      ],
+      "notes": "Rust Media-over-QUIC transport and relay stack. The interop relay enables draft-18 and uses the ADR 0033 experiment value of 750 ms for unresolved-track subscriptions; the shipped product default remains 2 s.",
+      "roles": {
+        "relay": {
+          "docker": {
+            "image": "kvick-relay:latest",
+            "url": "https://relay:4443",
+            "build": {
+              "dockerfile": "builds/kvick/Dockerfile.relay",
+              "context": ".sources/kvick"
+            },
+            "notes": "Build from source: ./builds/kvick/build.sh --target relay (use --local /path/to/kvick-ai for development)."
+          }
+        }
+      }
+    },
     "libquicr": {
       "name": "libquicr",
       "organization": "Cisco",


### PR DESCRIPTION
## Summary

- register kvick as a source-buildable relay for drafts 14, 16, 17, and 18
- add a reproducible Docker build and runner-compatible relay entrypoint
- configure the #3827 interoperability experiment at 750 ms while leaving kvick's shipped 2 s default unchanged
- test the entrypoint's certificate, port, catch-all origin, and grace configuration contract

## Why

Kvick's unknown-track subscription policy is already recorded and implemented, but it was not registered in this runner. That prevented the remaining `subscribe-error` / `subscribe-before-announce` evidence from being reproduced as an ordinary client × relay matrix slice.

## Verification

- `builds/kvick/test-entrypoint.sh`
- `bash -n builds/kvick/*.sh`
- `./validate-registration.sh --impl kvick` (all checks passed with the locally built image)
- Docker image built from kvick commit `38cbcd4a`
- aiomoqt draft-14, 5 repetitions each:
  - `subscribe-error`: 5/5 pass, 751.9–754.1 ms
  - `subscribe-before-announce`: 5/5 pass, 752.8–753.8 ms

## Residual kept separate

The current moq-rs draft-18 client still times out after 10 s despite the relay settling its cold-track timer at 750 ms. A legacy moq-rs image additionally reports the response bytes as HTTP capsule type 0. That transport/client-response residual is not hidden by changing the accepted kvick relay policy in this harness PR.
