### PR TITLE
Add stitcher-moq public relay endpoints (Pluto TV / Paramount)

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -530,6 +530,36 @@
         }
       }
     },
+    "stitcher-moq": {
+      "name": "stitcher-moq relay (moq-dev deployment)",
+      "organization": "Pluto TV / Paramount",
+      "repository": "https://github.com/moq-dev/moq",
+      "draft_versions": [
+        "draft-14",
+        "draft-15",
+        "draft-16",
+        "draft-17",
+        "draft-18",
+        "draft-19"
+      ],
+      "notes": "Stock moq-dev moq-relay (v0.14.8) fronting Pluto TV's MoQ SSAI sandbox on GCP. Anonymous subscribe; anonymous publish scoped to the moq-test prefix. Single UDP+TCP 443 via L4 passthrough LB, ACME certificate. Publishes live demo channels 24/7.",
+      "roles": {
+        "relay": {
+          "remote": [
+            {
+              "url": "https://34-72-6-160.sslip.io:443",
+              "transport": "webtransport",
+              "notes": "WebTransport endpoint"
+            },
+            {
+              "url": "moqt://34-72-6-160.sslip.io:443",
+              "transport": "quic",
+              "notes": "Raw QUIC endpoint"
+            }
+          ]
+        }
+      }
+    },
     "xquic": {
       "name": "xquic",
       "organization": "Alibaba",


### PR DESCRIPTION
Registers **`stitcher-moq`** — a public relay endpoint operated by Pluto TV / Paramount (streaming architecture team) — as a remote-only relay row, ahead of the Sept 2 virtual interop.

## Deployment

- **Stock [moq-dev](https://github.com/moq-dev/moq) `moq-relay` v0.14.8** fronting our MoQ SSAI sandbox on GCP (us-central1), running 24/7 with live demo channels.
- **One address for both transports:** `34-72-6-160.sslip.io:443` — an L4 passthrough LB forwards UDP 443 (WebTransport + raw QUIC, ALPN-blind) and TCP 443 (cert-hash endpoint / WS fallback).
- **Real ACME certificate** — no `tls_disable_verify`.
- **Auth:** anonymous subscribe; anonymous publish scoped to the `moq-test` prefix (covers the suite's `moq-test/interop` namespace). Other namespaces are JWT-gated.
- **`draft_versions`:** v0.14.8 advertises ALPNs `moqt-14` through `moqt-19`; we have session receipts at 18 and 19 (so this row can pair with `moq-go` at draft-19).

## Verification

- `./validate-registration.sh --impl stitcher-moq`: schema ✅, plan = 30 runs (15 client pairs × 2 transports).
- Ran the canonical draft-18 client (built from cloudflare/moq-rs `draft-18-dev` as of Aug 16) against the endpoint from the public internet today, `TLS_DISABLE_VERIFY=false`:
  - WebTransport `https://34-72-6-160.sslip.io:443` → **6/6, exit 0**
  - Raw QUIC `moqt://34-72-6-160.sslip.io:443` → **6/6, exit 0**

One observation while verifying (not specific to this endpoint): the GHCR `moq-test-client-draft-18:latest` image (built Jul 23) currently fails 5/6 against moq-dev 0.14.x relays — same `InvalidMessage(80)` / `short buffer` signature against this endpoint and against `cdn.moq.dev/anon`, matching last night's `moq-dev-rs` column — while an Aug 16 build of the same client passes 6/6. A rebuild of the moq-rs draft-18 client images would likely recover those cells; happy to open a separate issue with logs if useful.

**Contact:** steven.riedl@pluto.tv (GitHub: @riedlse). We watch the nightly matrix and will flip the endpoints to `"status": "inactive"` during maintenance windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
