### PR TITLE
moqlivemock: draft-18

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -324,10 +324,9 @@
       "organization": "Eyevinn",
       "repository": "https://github.com/Eyevinn/moqlivemock",
       "draft_versions": [
-        "draft-14",
-        "draft-16"
+        "draft-18"
       ],
-      "notes": "Go implementation. Test client and live CMAF publisher. Publisher announces the moq-test/interop namespace for interop testing.",
+      "notes": "Go implementation, draft-18 only. Test client and live CMAF publisher. Publisher announces the moq-test/interop namespace for interop testing.",
       "roles": {
         "client": {
           "docker": {


### PR DESCRIPTION
Moves `moqlivemock` to `["draft-18"]`.

### Why draft-18 only

[moqlivemock v0.14.0](https://github.com/Eyevinn/moqlivemock/releases/tag/v0.14.0)
implements draft-18 and drops drafts 14 and 16. From draft-17 the ALPN is the
whole of version negotiation, so it cannot reach an older peer at all — the
handshake fails before any MOQT is exchanged, and a mixed registration would
just produce failing cells. The `v0.13.x` line remains for draft-14/16.

### Both roles verified on draft-18

**Client** — `ghcr.io/eyevinn/mlmtest:latest` now carries the draft-18 build
(revision `13fa4057`), and still honours `RELAY_URL`, `TESTCASE`,
`TLS_DISABLE_VERIFY` and `DRAFT`. Ran the docker pairing locally against that
exact image:

```
moqlivemock → moq-rs-draft-18   draft-18 (at-target)   ✓ PASSED   (6/6)
  ok 1 - setup-only             ok 4 - subscribe-error
  ok 2 - announce-only          ok 5 - announce-subscribe
  ok 3 - publish-namespace-done ok 6 - subscribe-before-announce
```

**Publisher** — `moqlivemock.demo.osaas.io` has been redeployed to v0.14.0.
Both registered endpoints answer draft-18:

- `moqt://moqlivemock.demo.osaas.io:443` — 6/6, `# Draft: 18 (ALPN: moqt-18)`
- `https://moqlivemock.demo.osaas.io:443/moq` — `MoQ session established
  version=moqt-18`, media flowing

The publisher endpoints are unchanged; only `draft_versions` and the notes
string move.

`./validate-registration.sh --impl moqlivemock` passes: schema valid, **21 runs
planned, all at-target draft-18**, image reachable.

### One finding, offered rather than filed

Against `imquic` the same image gets 3/6. `publish-namespace-done` fails with
`PUBLISH_NAMESPACE: request rejected: INTERNAL_ERROR: Namespace already
published`, and the two later namespace tests fail downstream of it. draft-18
ends a PUBLISH_NAMESPACE by closing its request stream rather than with an
explicit message, so this looks like the namespace not being released on stream
close — but I have not run a draft-16 control to confirm it is new, and the
image is amd64 under emulation here, so I am flagging it rather than asserting
it. Happy to chase it separately.
