### PR TITLE
docs: define interop reporting and test lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ This is a framework for testing interoperability between MoQT (Media over QUIC T
 |------|------------|
 | Understand the project | `README.md` |
 | Get started as a contributor | `docs/GETTING-STARTED.md` |
-| See test case definitions | `docs/tests/TEST-CASES.md` |
+| See test catalog and definitions | `docs/tests/README.md` |
 | Build a test client | `docs/IMPLEMENTING-A-TEST-CLIENT.md` |
 | Test client interface contract | `docs/TEST-CLIENT-INTERFACE.md` |
 | Docker testing workflows | `docs/DOCKER-TESTING.md` |
@@ -93,7 +93,8 @@ Full guide: `docs/IMPLEMENTING-A-TEST-CLIENT.md`
 
 ### Adding or Modifying Test Cases
 
-Test cases are defined in `docs/tests/TEST-CASES.md`. Current tests:
+The test catalog and contribution process are in `docs/tests/README.md`.
+Existing test cases remain defined in `docs/tests/TEST-CASES.md`:
 
 | Identifier | Category | Description |
 |------------|----------|-------------|
@@ -105,7 +106,10 @@ Test cases are defined in `docs/tests/TEST-CASES.md`. Current tests:
 | `announce-subscribe` | Subscription | Publisher announces, subscriber subscribes |
 | `subscribe-before-announce` | Subscription | Out-of-order subscribe/announce |
 
-When adding tests, follow the existing format (identifier, protocol refs, procedure, success criteria). Both the spec doc and test client implementations need updates.
+When adding tests, follow `docs/tests/README.md`. A new test may be implemented
+by one client before other clients adopt it. Treat the absence of a result as
+unknown rather than unsupported. Keep unrelated test scenarios in separate
+commits when practical so they can be reviewed independently.
 
 ### Maintaining the Framework
 

--- a/IMPLEMENTATIONS.md
+++ b/IMPLEMENTATIONS.md
@@ -119,10 +119,14 @@ Standard environment variables (optional but recommended):
 
 Remote endpoints specify their transport type:
 
-| Transport | URL Scheme | Description |
-|-----------|------------|-------------|
-| `webtransport` | `https://` | WebTransport (supported in browsers) |
-| `quic` | `moqt://` | Raw QUIC |
+| Transport | Accepted URL Scheme | Description |
+|-----------|---------------------|-------------|
+| `webtransport` | `https://` or `moqt://` | WebTransport (`https://` remains a compatibility locator; draft 18 and later use canonical `moqt://`) |
+| `quic` | `moqt://` | Native QUIC |
+
+The `transport` field records the intended transport independently of the URL
+scheme. See [Decision 003](docs/decisions/003-url-scheme-transport-selection.md)
+for the migration plan.
 
 Optional endpoint properties:
 - `tls_disable_verify`: Set `true` for self-signed certificates

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ Tests are organized by functional category:
 | `announce-subscribe` | Subscription | Publisher announces, subscriber subscribes |
 | `subscribe-before-announce` | Subscription | Subscribe before publisher announces |
 
-See [docs/tests/TEST-CASES.md](./docs/tests/TEST-CASES.md) for detailed specifications with protocol references.
+See the [test catalog](./docs/tests/README.md) for organization and contribution
+guidance, and [docs/tests/TEST-CASES.md](./docs/tests/TEST-CASES.md) for the
+existing detailed specifications with protocol references.
 
 ## Architecture
 
@@ -142,7 +144,7 @@ See [docs/tests/TEST-CASES.md](./docs/tests/TEST-CASES.md) for detailed specific
 Contributions welcome! Key areas:
 
 1. **Add your implementation** - See [IMPLEMENTATIONS.md](./IMPLEMENTATIONS.md)
-2. **Propose new test cases** - Open an issue or PR to `docs/tests/TEST-CASES.md`
+2. **Propose new test cases** - Follow the [test contribution process](./docs/tests/README.md)
 3. **Build a test client** - See [docs/IMPLEMENTING-A-TEST-CLIENT.md](./docs/IMPLEMENTING-A-TEST-CLIENT.md)
 4. **Improve tooling** - Better reporting, CI integration, etc.
 

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -33,7 +33,7 @@ The interop runner expects client images to follow:
 
 | Convention | Description |
 |------------|-------------|
-| `RELAY_URL` | Relay URL (`https://` for WebTransport, `moqt://` for raw QUIC) |
+| `RELAY_URL` | Relay locator (`https://` for legacy WebTransport clients; `moqt://` for native QUIC or draft 18 and later WebTransport) |
 | `TESTCASE` | Specific test to run (optional; runs all if not set) |
 | `TLS_DISABLE_VERIFY=1` | Skip TLS certificate verification |
 | TAP version 14 on stdout | Machine-parseable test output |

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -85,8 +85,8 @@ Here's what each field means and what to check:
 | `draft_versions` | **Most important.** Array of MoQT draft versions your implementation currently supports (format: `draft-NN`). If you've added draft-16 support or dropped older versions, update this. The runner uses this to decide which client/relay pairs to test. |
 | `notes` | Brief description — anything important reviewers should know? |
 | `roles` | Which roles your implementation supports. Most implementations start as `relay` only. If you've built a test client, add a `client` role (see [Issue #13](https://github.com/englishm/moq-interop-runner/issues/13)). |
-| `remote[].url` | Your public endpoint URL. `https://` for WebTransport, `moqt://` for raw QUIC. Is this endpoint still running? Has the port or path changed? |
-| `remote[].transport` | `webtransport` or `quic` — does this match the URL scheme? |
+| `remote[].url` | Your public endpoint URL. The runner accepts `https://` as a legacy WebTransport locator and `moqt://` for native QUIC or draft 18 and later WebTransport. Is this endpoint still running? Has the port or path changed? |
+| `remote[].transport` | `webtransport` or `quic` - does this describe the intended transport independently of the URL scheme? |
 | `remote[].tls_disable_verify` | Set to `true` if your endpoint uses a self-signed certificate. If you've switched to a CA-signed cert, you can remove this. |
 | `remote[].status` | Optional. Set to `"inactive"` to temporarily exclude an endpoint from test runs without removing it. Omit or set to `"active"` for live endpoints. |
 
@@ -115,7 +115,7 @@ Roughly ordered by time investment:
 | Run tests against my public relay | 5 min | [Test Your Relay](#test-your-relay) |
 | Register my implementation for the first time | 15 min | [Add Your Implementation](#add-your-implementation) |
 | Build a test client for my MoQT stack | 2-4 hours | [Build a Test Client](#build-a-test-client) |
-| Propose or spec new test cases | — | [docs/tests/TEST-CASES.md](./tests/TEST-CASES.md) |
+| Propose or spec new test cases | — | [Test contribution process](./tests/README.md) |
 
 ## Test Your Relay
 

--- a/docs/IMPLEMENTING-A-TEST-CLIENT.md
+++ b/docs/IMPLEMENTING-A-TEST-CLIENT.md
@@ -8,7 +8,9 @@ This guide explains how to implement a test client for your MoQT stack that's co
 
 Most MoQT implementations already have CLI tools (moq-rs has `moq-pub`/`moq-sub`/`moq-clock`, moxygen has `moqtest_client`, etc.), but each exercises different scenarios with different output. The goal here is **multiple implementations of the *same* test cases** — standard identifiers (`setup-only`, `announce-subscribe`, ...) with precise success criteria so we can automate the full client x relay matrix with machine-parseable results instead of ad-hoc commands and manual spreadsheet tracking.
 
-If you already have a MoQT implementation, building a test client mostly means wiring your existing protocol logic to the scenarios defined in [TEST-CASES.md](./tests/TEST-CASES.md).
+If you already have a MoQT implementation, building a test client mostly means
+wiring your existing protocol logic to scenarios in the
+[test catalog](./tests/README.md).
 
 ## Overview
 
@@ -30,7 +32,9 @@ Your test client MUST implement the interface defined in [TEST-CLIENT-INTERFACE.
 
 ## Test Case Implementation
 
-For each test case you support, implement the procedure described in [tests/TEST-CASES.md](./tests/TEST-CASES.md).
+For each test case you support, follow the prose specification linked from the
+[test catalog](./tests/README.md). Existing tests remain collected in
+[TEST-CASES.md](./tests/TEST-CASES.md).
 
 ### Example: `setup-only`
 
@@ -52,7 +56,9 @@ def test_setup_only(relay_url):
             return TestResult.fail(
                 f"Expected SERVER_SETUP, got {msg.type}",
                 duration=time.now() - start,
-                connection_id=conn.id
+                sessions={"client": {
+                    "quic_initial_destination_connection_id": conn.initial_dcid
+                }}
             )
         
         # 4. Close gracefully
@@ -60,7 +66,9 @@ def test_setup_only(relay_url):
         
         return TestResult.pass(
             duration=time.now() - start,
-            connection_id=conn.id
+            sessions={"client": {
+                "quic_initial_destination_connection_id": conn.initial_dcid
+            }}
         )
         
     except Timeout:
@@ -102,20 +110,26 @@ def test_subscribe_error(relay_url):
             conn.close()
             return TestResult.pass(
                 duration=time.now() - start,
-                connection_id=conn.id
+                sessions={"subscriber": {
+                    "quic_initial_destination_connection_id": conn.initial_dcid
+                }}
             )
         elif msg.type == SUBSCRIBE_OK:
             # Unexpected success
             return TestResult.fail(
                 "Expected SUBSCRIBE_ERROR, got SUBSCRIBE_OK",
                 duration=time.now() - start,
-                connection_id=conn.id
+                sessions={"subscriber": {
+                    "quic_initial_destination_connection_id": conn.initial_dcid
+                }}
             )
         else:
             return TestResult.fail(
                 f"Unexpected message type: {msg.type}",
                 duration=time.now() - start,
-                connection_id=conn.id
+                sessions={"subscriber": {
+                    "quic_initial_destination_connection_id": conn.initial_dcid
+                }}
             )
             
     except Timeout:
@@ -165,7 +179,14 @@ def test_announce_subscribe(relay_url):
             sub.close()
             return TestResult.pass(
                 duration=time.now() - start,
-                extra=f"pub={pub.id[:8]}, sub={sub.id[:8]}"
+                sessions={
+                    "publisher": {
+                        "quic_initial_destination_connection_id": pub.initial_dcid
+                    },
+                    "subscriber": {
+                        "quic_initial_destination_connection_id": sub.initial_dcid
+                    },
+                }
             )
         else:
             return TestResult.fail(
@@ -214,22 +235,19 @@ def format_tap_result(number, result):
         line += f" # SKIP {result.skip_reason}"
         return line
 
-    # Add YAML diagnostic block for richer context
-    yaml_lines = []
+    # Use a YAML library so arbitrary diagnostic strings are escaped safely.
+    metadata = {}
     if result.duration_ms is not None:
-        yaml_lines.append(f"  duration_ms: {result.duration_ms}")
-    if result.connection_id:
-        yaml_lines.append(f"  connection_id: {result.connection_id}")
+        metadata["duration_ms"] = result.duration_ms
+    if result.sessions:
+        metadata["sessions"] = result.sessions
     if not result.passed and result.message:
-        yaml_lines.append(f"  message: \"{result.message}\"")
-    if result.expected:
-        yaml_lines.append(f"  expected: {result.expected}")
-    if result.received:
-        yaml_lines.append(f"  received: {result.received}")
+        metadata["message"] = result.message
 
-    if yaml_lines:
+    if metadata:
+        rendered = yaml.safe_dump(metadata, sort_keys=False).rstrip()
         line += "\n  ---\n"
-        line += "\n".join(yaml_lines)
+        line += textwrap.indent(rendered, "  ")
         line += "\n  ..."
 
     return line
@@ -249,16 +267,18 @@ Don't let tests hang indefinitely - always fail with a clear timeout message.
 
 When `--tls-disable-verify` is set (or `TLS_DISABLE_VERIFY=1`), disable certificate verification. This is necessary for testing with self-signed certificates in containerized environments.
 
-## Connection ID Extraction
+## QUIC Connection ID Extraction
 
-Extract the QUIC connection ID for mlog correlation and include it in the YAML diagnostic block. This is typically available from your QUIC implementation:
+Include the client's QUIC Initial Destination Connection ID under the logical
+session role when the QUIC stack exposes it. APIs differ by stack; use the
+Destination Connection ID from the client's first QUIC Initial packet, not a
+process-local connection handle. Omit the field for non-QUIC sessions or when
+the value is unavailable. Encode the bytes as lowercase hexadecimal without
+separators or a `0x` prefix:
 
 ```python
-# Example with quinn (Rust)
-let cid = connection.stable_id();
-
-# Example with aioquic (Python)  
-cid = connection._quic.host_cid.hex()
+# Pseudocode; use the equivalent API in your QUIC stack.
+cid = connection.initial_destination_connection_id()
 ```
 
 In TAP output, the connection ID appears in the YAML diagnostics:
@@ -267,7 +287,9 @@ In TAP output, the connection ID appears in the YAML diagnostics:
 ok 1 - setup-only
   ---
   duration_ms: 24
-  connection_id: 84ee7793841adcadd926a1baf1c677cc
+  sessions:
+    client:
+      quic_initial_destination_connection_id: "84ee7793841adcadd926a1baf1c677cc"
   ...
 ```
 
@@ -277,8 +299,11 @@ For multi-connection tests, include both IDs:
 ok 2 - announce-subscribe
   ---
   duration_ms: 156
-  publisher_connection_id: abc12345
-  subscriber_connection_id: def67890
+  sessions:
+    publisher:
+      quic_initial_destination_connection_id: "abc1234567890def"
+    subscriber:
+      quic_initial_destination_connection_id: "def6789012345abc"
   ...
 ```
 

--- a/docs/TAP-YAML-METADATA.md
+++ b/docs/TAP-YAML-METADATA.md
@@ -1,0 +1,168 @@
+# TAP YAML Metadata
+
+TAP version 14 permits a YAML diagnostic block after a test point. Test clients
+may use these blocks to report structured context in addition to the test's
+`ok` or `not ok` result.
+
+Every field in this document is currently optional. A client that emits no YAML
+remains compatible with the current runner and existing nightly interop report.
+The runner and report generator in this repository are the primary consumers of
+these fields.
+
+As of September 2026, the runner preserves the client output but does not parse
+these fields into the nightly report.
+
+As implementations adopt the fields, future reports can group results by the
+MoQT version and transport actually negotiated, distinguish the protocol stack
+selected in fallback scenarios,
+compare results that use the same test specification revision, and link a
+failure to session logs. This metadata adds context; it does not alter the TAP
+pass or fail result.
+
+## Example
+
+```tap
+not ok 1 - announce-subscribe
+  ---
+  duration_ms: 3200
+  implementation_version: "31c73575"
+  sessions:
+    publisher:
+      moqt_version: "moqt-18"
+      transport: "quic"
+      alpn: "moqt-18"
+      quic_initial_destination_connection_id: "abc1234567890def"
+    subscriber:
+      moqt_version: "moqt-18"
+      transport: "quic"
+      alpn: "moqt-18"
+      quic_initial_destination_connection_id: "def4567890abcdef"
+  message: "subscriber did not receive the expected object"
+  ...
+```
+
+The TAP description should be the stable identifier from the
+[test catalog](./tests/README.md). The block follows the indentation rules in
+[TEST-CLIENT-INTERFACE.md](./TEST-CLIENT-INTERFACE.md#yaml-diagnostics).
+
+## Common Fields
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `duration_ms` | non-negative integer | Total elapsed time for this test in milliseconds |
+| `implementation_version` | string | Client release, source revision, or build identifier |
+| `test_spec_revision` | positive integer | Revision of the prose specification implemented by the client |
+| `udp_blocked` | boolean | Whether the test environment intentionally made UDP unavailable for this test |
+| `sessions` | mapping | Session details keyed by logical role from the test specification |
+| `message` | string | Concise human-readable diagnostic context |
+
+`duration_ms` covers the complete test, from immediately before its first
+test-specific action through its procedure and verification. It is not an
+object-delivery latency or any other narrower timing measurement.
+
+`implementation_version` is opaque. Quote values that YAML might otherwise
+interpret as another type. The meaning and update rules for
+`test_spec_revision` are defined in
+[Test Specification Revisions](./tests/README.md#test-specification-revisions).
+
+`udp_blocked: true` records an intentional test condition, such as a fallback
+test where UDP has been made unavailable. It does not by itself claim that a
+QUIC attempt was made. Omit the field when the client does not know whether UDP
+was blocked.
+
+## Session Fields
+
+Each key under `sessions` is a stable logical role defined by the test, such as
+`client`, `publisher`, or `subscriber`. This allows each leg of a multi-session
+test to report what it actually negotiated.
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `moqt_version` | string | Normalized MoQT protocol identifier selected for this session, such as `moqt-18` or the final `moqt` |
+| `transport` | string | Selected transport stack from the values below |
+| `alpn` | string | Exact ALPN selected on the underlying QUIC or TLS connection |
+| `webtransport_protocol` | string | Exact WebTransport application protocol selected in `WT-Protocol`; omitted unless WebTransport is used |
+| `websocket_subprotocol` | string | Exact WebSocket subprotocol selected in `Sec-WebSocket-Protocol`; omitted unless WebSocket is used |
+| `quic_initial_destination_connection_id` | string | Client's Initial Destination Connection ID as lowercase hexadecimal without separators or a `0x` prefix; omitted when unavailable or no QUIC connection is used |
+
+For drafts 15 and later, the MoQT version is selected by the MoQT ALPN for
+native QUIC or by WebTransport application protocol negotiation. Earlier
+drafts used the `moq-00` ALPN and selected a version during SETUP.
+`moqt_version` normalizes the selected version to the protocol identifier form
+(`moqt-NN` for an Internet-Draft and `moqt` for the final protocol), including
+when an earlier draft selected its version in SETUP. It reports the version
+actually selected by the applicable mechanism, not a requested, predicted, or
+maximum supported version. The raw `alpn`, `webtransport_protocol`, and
+`websocket_subprotocol` fields provide supporting negotiation evidence when an
+implementation exposes it. An experimental QMux mapping can use the same
+normalized `moqt_version` while reporting its actual ALPN or selected WebSocket
+subprotocol as raw evidence.
+
+The initial `transport` values are:
+
+| Value | Stack |
+|-------|-------|
+| `quic` | Native MoQT over QUIC |
+| `webtransport-h3` | MoQT over WebTransport over HTTP/3 and QUIC |
+| `webtransport-h2` | MoQT over WebTransport over HTTP/2 and TLS/TCP |
+| `qmux-wss` | MoQT over QMux over secure WebSocket |
+| `qmux-tcp-tls` | MoQT over QMux over TLS/TCP |
+
+The QMux values describe experimental mappings rather than transports defined
+by the core MoQT specification. `qmux-tcp-tls` refers to QMux draft 02 over
+TLS/TCP; an application mapping must assign it an ALPN distinct from the same
+application's native QUIC ALPN. `qmux-wss` additionally uses the QMux over
+WebSocket draft 00 binding, which carries the application's native QUIC
+identifier in `Sec-WebSocket-Protocol`. The expired MOQT over QMux draft 00
+proposes a MoQT mapping over QMux/TLS/TCP that reuses the native `moqt-NN`
+ALPN, but it references an earlier QMux draft and its ALPN choice does not
+satisfy QMux draft 02's mapping-specific requirement. It does not define the
+WebSocket mapping. No MoQT-over-QMux identifier aligned with the current QMux
+draft is standardized yet. Reports record the identifier actually selected;
+new values can be documented as transports evolve. A report that does not
+recognize a value leaves it unclassified rather than rejecting the result.
+
+The runner does not currently provide a way to block UDP. A future fallback
+test that intentionally adds this condition could report:
+
+```tap
+ok 1 - setup-only
+  ---
+  duration_ms: 4187
+  implementation_version: "v0.4.2"
+  udp_blocked: true
+  sessions:
+    client:
+      moqt_version: "moqt-18"
+      transport: "webtransport-h2"
+      alpn: "h2"
+      webtransport_protocol: "moqt-18"
+  ...
+```
+
+## How Compatibility Works
+
+- YAML augments a TAP result; it does not replace the test point or plan.
+- An omitted field will be interpreted as unknown or unreported, not as a
+  default value.
+- Clients report versions and transports they actually negotiated, not values
+  requested or predicted before the session was established.
+- The runner and report generator ignore fields and values they do not yet
+  classify.
+- The runner continues to accept TAP output without YAML diagnostics.
+- Existing producer-specific fields remain valid even when they are not part of
+  the shared vocabulary documented here.
+- New fields can be documented without requiring coordinated client upgrades.
+
+YAML blocks are the preferred place for structured diagnostics because they do
+not interfere with TAP parsing. Plain TAP remains valid, and TAP comments remain
+available for additional human-readable context.
+
+## Protocol References
+
+- [MoQT draft 18, Version Negotiation](https://www.ietf.org/archive/id/draft-ietf-moq-transport-18.html#section-3.1)
+- [WebTransport over HTTP/3, Protocol Negotiation](https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-16.html#section-3.3)
+- [WebTransport over HTTP/2](https://www.ietf.org/archive/id/draft-ietf-webtrans-http2-15.html)
+- [QMux draft 02](https://www.ietf.org/archive/id/draft-ietf-quic-qmux-02.html)
+- [QMux over WebSocket draft 00](https://www.ietf.org/archive/id/draft-lcurley-qmux-websocket-00.html)
+- [MOQT over QMux draft 00](https://www.ietf.org/archive/id/draft-nandakumar-moq-qmux-moqt-00.html)

--- a/docs/TEST-CLIENT-INTERFACE.md
+++ b/docs/TEST-CLIENT-INTERFACE.md
@@ -21,8 +21,24 @@ Options:
 
 ### URL Schemes
 
-- `https://` - WebTransport over HTTP/3
-- `moqt://` - Raw QUIC with ALPN `moq-00`
+The current runner accepts both `https://` and `moqt://` relay URLs because
+implementations span several generations of the protocol:
+
+- Through MoQT draft 17, `https://` identifies a WebTransport endpoint and
+  `moqt://` identifies a native QUIC endpoint.
+- Beginning with draft 18, `moqt://` is the canonical URI scheme for both
+  transports. A client can offer native MoQT ALPNs and `h3` on QUIC; selecting
+  `h3` leads the client to derive an `https://` URI and establish WebTransport.
+
+Many current clients still use the URI scheme as their transport selector. The
+runner therefore continues to accept `https://` as a legacy WebTransport
+locator, including for implementations of newer drafts that have not adopted
+the unified URI behavior. New draft 18 and later integrations should use
+`moqt://`. A planned runner interface will constrain native QUIC or
+WebTransport independently of the URI; until then, adapters may translate the
+canonical URI to the locator a client expects. See
+[Decision 003](./decisions/003-url-scheme-transport-selection.md) for the
+migration plan.
 
 ## Environment Variable Interface
 
@@ -30,7 +46,7 @@ For containerized testing, the following environment variables are supported:
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `RELAY_URL` | Yes | Relay URL (`https://` for WebTransport, `moqt://` for raw QUIC) |
+| `RELAY_URL` | Yes | Relay locator; accepted schemes and compatibility behavior are described above |
 | `TESTCASE` | No | Specific test to run (runs all if not set) |
 | `TLS_DISABLE_VERIFY` | No | Set to `1` to skip certificate verification |
 | `VERBOSE` | No | Set to `1` for verbose output |
@@ -103,7 +119,12 @@ The harness counts skipped tests separately from passes and failures.
 
 ### YAML Diagnostics
 
-YAML diagnostic blocks after test points are OPTIONAL but encouraged, especially for failures. They provide structured metadata the harness can use for richer reporting.
+YAML diagnostic blocks after test points are OPTIONAL but encouraged, especially
+for failures. They are the preferred place for structured metadata because they
+do not interfere with TAP parsing.
+
+[TAP YAML Metadata](./TAP-YAML-METADATA.md) defines additional common
+field names. All fields remain optional, and the runner ignores unknown fields.
 
 ```tap
 TAP version 14
@@ -111,64 +132,58 @@ TAP version 14
 ok 1 - setup-only
   ---
   duration_ms: 24
-  connection_id: 84ee7793841adcadd926a1baf1c677cc
+  sessions:
+    client:
+      moqt_version: "moqt-18"
+      transport: "quic"
+      quic_initial_destination_connection_id: "84ee7793841adcadd926a1baf1c677cc"
   ...
 ok 2 - announce-only
   ---
   duration_ms: 31
-  connection_id: a1b2c3d4e5f6789
+  sessions:
+    publisher:
+      quic_initial_destination_connection_id: "a1b2c3d4e5f67890"
   ...
 not ok 3 - subscribe-error
   ---
   duration_ms: 2001
-  expected: SUBSCRIBE_ERROR
-  received: timeout
-  connection_id: def789
+  message: "timed out waiting for REQUEST_ERROR"
+  sessions:
+    subscriber:
+      quic_initial_destination_connection_id: "def7890123456789"
   ...
 ok 4 - announce-subscribe
   ---
   duration_ms: 145
-  publisher_connection_id: abc12345
-  subscriber_connection_id: def67890
+  sessions:
+    publisher:
+      quic_initial_destination_connection_id: "abc1234567890def"
+    subscriber:
+      quic_initial_destination_connection_id: "def6789012345abc"
   ...
 ```
 
-YAML blocks MUST be indented 2 spaces relative to the test point they follow. Common fields:
+YAML blocks MUST be indented 2 spaces relative to the test point they follow.
+Each prose specification linked from the [test catalog](./tests/README.md)
+defines its logical session roles. Use those names as keys under `sessions`
+rather than identifying sessions by connection order. If a test has two roles
+of the same kind, its specification assigns distinct names such as
+`subscriber_1` and `subscriber_2`.
 
-| Field | Description |
-|-------|-------------|
-| `duration_ms` | Test duration in milliseconds |
-| `connection_id` | QUIC connection ID for mlog correlation (single-connection tests) |
-| `expected` | What the test expected |
-| `received` | What actually happened |
-
-#### Connection ID Conventions
-
-Connection IDs in YAML diagnostics enable correlation with relay-side mlog/qlog traces. The naming convention depends on the test topology:
-
-- **Single-connection tests** use `connection_id`:
-  ```yaml
-  connection_id: 84ee7793841adcadd926a1baf1c677cc
-  ```
-
-- **Multi-connection tests** use `<role>_connection_id`, where `<role>` is the logical role defined by the test case (e.g., `publisher`, `subscriber`):
-  ```yaml
-  publisher_connection_id: abc12345
-  subscriber_connection_id: def67890
-  ```
-
-The expected roles for each test case are documented in [TEST-CASES.md](./tests/TEST-CASES.md). Implementations SHOULD name connections by role rather than by connection order to avoid fragile positional coupling — the output code should not need to know which role connects first.
-
-Future tests with multiple connections in the same role (e.g., two subscribers) SHOULD use numbered suffixes: `subscriber_1_connection_id`, `subscriber_2_connection_id`.
-
-**Partial failure**: Connection IDs are best-effort. If a test fails partway through, include whatever connection IDs were successfully captured before the failure. For example, if the publisher connects but the subscriber fails:
+**Partial failure**: QUIC Initial Destination Connection IDs are best-effort.
+Include whatever IDs were captured before the failure and omit the field for
+non-QUIC sessions or when the implementation does not expose it. For example,
+if the publisher connects but the subscriber fails:
 
 ```tap
 not ok 5 - announce-subscribe
   ---
   duration_ms: 3001
-  publisher_connection_id: abc12345
   message: "subscriber connection failed"
+  sessions:
+    publisher:
+      quic_initial_destination_connection_id: "abc1234567890def"
   ...
 ```
 
@@ -226,20 +241,22 @@ Test clients MUST implement timeouts to prevent hanging:
 
 - Individual tests SHOULD timeout after their specified duration (see test case specs)
 - If no timeout is specified, default to 5 seconds
-- On timeout, report the test as failed with a clear message in the YAML diagnostics
+- On timeout, report the test as failed. A client MAY include a clear message in
+  optional YAML diagnostics.
 
 ## Error Reporting
 
-When tests fail, include diagnostic context via YAML blocks:
+When tests fail, clients SHOULD include diagnostic context. Optional YAML blocks
+are the preferred way to provide structured details:
 
 ```tap
 not ok 2 - announce-only
   ---
   duration_ms: 2001
-  expected: PUBLISH_NAMESPACE_OK
-  received: timeout
-  message: "no response after 2000 ms"
-  connection_id: 84ee7793841adcadd926a1baf1c677cc
+  message: "timed out waiting for REQUEST_OK after 2000 ms"
+  sessions:
+    publisher:
+      quic_initial_destination_connection_id: "84ee7793841adcadd926a1baf1c677cc"
   ...
 ```
 
@@ -249,9 +266,9 @@ For protocol errors:
 not ok 3 - subscribe-error
   ---
   duration_ms: 45
-  expected: SUBSCRIBE_ERROR
-  received: SUBSCRIBE_OK
-  message: "unexpected success"
-  connection_id: 84ee7793841adcadd926a1baf1c677cc
+  message: "received SUBSCRIBE_OK instead of REQUEST_ERROR"
+  sessions:
+    subscriber:
+      quic_initial_destination_connection_id: "84ee7793841adcadd926a1baf1c677cc"
   ...
 ```

--- a/docs/TEST-SPECIFICATIONS.md
+++ b/docs/TEST-SPECIFICATIONS.md
@@ -4,6 +4,7 @@ This document has been reorganized into separate, focused documents:
 
 | Document | Content |
 |----------|---------|
+| **[tests/README.md](./tests/README.md)** | Test catalog, lifecycle labels, support levels, and profiles |
 | **[tests/TEST-CASES.md](./tests/TEST-CASES.md)** | Test case definitions with protocol references |
 | **[TEST-CLIENT-INTERFACE.md](./TEST-CLIENT-INTERFACE.md)** | CLI, environment variables, exit codes, output format |
 | **[IMPLEMENTING-A-TEST-CLIENT.md](./IMPLEMENTING-A-TEST-CLIENT.md)** | Guide for implementing a compatible test client |

--- a/docs/decisions/001-tap-output-format.md
+++ b/docs/decisions/001-tap-output-format.md
@@ -61,7 +61,10 @@ TAP hits all the goals well:
 
 - **Streaming by design.** Each test point is a single line emitted as the test completes. A human watching a terminal or a CI system tailing logs sees progress in real time.
 
-- **YAML diagnostics.** TAP14 supports optional YAML blocks after any test point. This is how we get extensible metadata (connection IDs, mlog paths, latency, expected/received values) without complicating the base format. Basic parsers that don't understand YAML still work fine.
+- **YAML diagnostics.** TAP14 supports optional YAML blocks after any test point.
+  This provides extensible session, timing, and failure context without
+  complicating the base format. Basic parsers that don't understand YAML still
+  work fine.
 
 - **SKIP and TODO directives.** `SKIP` maps directly to "this test client doesn't implement this test case." `TODO` could represent known issues. The harness can distinguish "not implemented" from "failed" without inventing custom conventions.
 
@@ -112,19 +115,24 @@ TAP version 14
 ok 1 - setup-only
   ---
   duration_ms: 24
-  connection_id: 84ee7793841adcadd926a1baf1c677cc
+  sessions:
+    client:
+      quic_initial_destination_connection_id: "84ee7793841adcadd926a1baf1c677cc"
   ...
 ok 2 - announce-only
   ---
   duration_ms: 31
-  connection_id: a1b2c3d4e5f6789
+  sessions:
+    publisher:
+      quic_initial_destination_connection_id: "a1b2c3d4e5f67890"
   ...
 not ok 3 - subscribe-error
   ---
   duration_ms: 2001
-  expected: SUBSCRIBE_ERROR
-  received: timeout
-  connection_id: def789
+  message: "timed out waiting for REQUEST_ERROR"
+  sessions:
+    subscriber:
+      quic_initial_destination_connection_id: "def7890123456789"
   ...
 ```
 
@@ -155,9 +163,9 @@ ok 3 - publish-namespace-done # SKIP not implemented
 
 ## Future Directions
 
-These are ideas, not commitments:
-
-- **YAML diagnostic schema.** Define a set of known field names (connection_id, duration_ms, mlog_path, expected, received, etc.) so implementations can align on metadata without us mandating it all upfront. Start optional, promote to required as the ecosystem matures.
+These are ideas, not commitments. The currently optional common YAML field names
+are documented in [TAP-YAML-METADATA.md](../TAP-YAML-METADATA.md); TAP output
+without YAML remains valid and sufficient for the current basic interop report.
 
 - **Output linting.** A tool that validates test client TAP output against the spec and any MoQT-specific conventions. Could catch issues before they surface as mysterious harness failures.
 

--- a/docs/decisions/001-tap-output-format.md
+++ b/docs/decisions/001-tap-output-format.md
@@ -2,6 +2,9 @@
 
 **Date:** 2026-02-06
 
+**Updated by:** [TAP YAML Metadata](../TAP-YAML-METADATA.md), which defines
+the current optional diagnostic field vocabulary.
+
 ## Problem
 
 The moq-interop-runner needs a standardized output format for test clients. Without one, every test client author invents their own output, making it difficult for the harness to parse results and for humans to compare behavior across implementations.
@@ -61,10 +64,7 @@ TAP hits all the goals well:
 
 - **Streaming by design.** Each test point is a single line emitted as the test completes. A human watching a terminal or a CI system tailing logs sees progress in real time.
 
-- **YAML diagnostics.** TAP14 supports optional YAML blocks after any test point.
-  This provides extensible session, timing, and failure context without
-  complicating the base format. Basic parsers that don't understand YAML still
-  work fine.
+- **YAML diagnostics.** TAP14 supports optional YAML blocks after any test point. This is how we get extensible metadata (connection IDs, mlog paths, latency, expected/received values) without complicating the base format. Basic parsers that don't understand YAML still work fine.
 
 - **SKIP and TODO directives.** `SKIP` maps directly to "this test client doesn't implement this test case." `TODO` could represent known issues. The harness can distinguish "not implemented" from "failed" without inventing custom conventions.
 
@@ -115,24 +115,19 @@ TAP version 14
 ok 1 - setup-only
   ---
   duration_ms: 24
-  sessions:
-    client:
-      quic_initial_destination_connection_id: "84ee7793841adcadd926a1baf1c677cc"
+  connection_id: 84ee7793841adcadd926a1baf1c677cc
   ...
 ok 2 - announce-only
   ---
   duration_ms: 31
-  sessions:
-    publisher:
-      quic_initial_destination_connection_id: "a1b2c3d4e5f67890"
+  connection_id: a1b2c3d4e5f6789
   ...
 not ok 3 - subscribe-error
   ---
   duration_ms: 2001
-  message: "timed out waiting for REQUEST_ERROR"
-  sessions:
-    subscriber:
-      quic_initial_destination_connection_id: "def7890123456789"
+  expected: SUBSCRIBE_ERROR
+  received: timeout
+  connection_id: def789
   ...
 ```
 
@@ -163,9 +158,9 @@ ok 3 - publish-namespace-done # SKIP not implemented
 
 ## Future Directions
 
-These are ideas, not commitments. The currently optional common YAML field names
-are documented in [TAP-YAML-METADATA.md](../TAP-YAML-METADATA.md); TAP output
-without YAML remains valid and sufficient for the current basic interop report.
+These are ideas, not commitments:
+
+- **YAML diagnostic schema.** Define a set of known field names (connection_id, duration_ms, mlog_path, expected, received, etc.) so implementations can align on metadata without us mandating it all upfront. Start optional, promote to required as the ecosystem matures.
 
 - **Output linting.** A tool that validates test client TAP output against the spec and any MoQT-specific conventions. Could catch issues before they surface as mysterious harness failures.
 

--- a/docs/decisions/003-url-scheme-transport-selection.md
+++ b/docs/decisions/003-url-scheme-transport-selection.md
@@ -1,0 +1,126 @@
+# Decision: URL Scheme and Transport Selection
+
+**Date:** 2026-09-06
+
+**Status:** Proposed migration; current runner behavior is unchanged
+
+## Problem
+
+The runner and many test clients use `https://` to select WebTransport and
+`moqt://` to select native QUIC. That was the protocol model through MoQT draft
+17. Beginning with draft 18, one `moqt://` URI identifies the MOQT resource and
+transport selection is negotiated separately.
+
+Changing every registered URL immediately would break implementations that
+still dispatch on the scheme. Keeping the historical convention indefinitely
+would make new integrations diverge from the current specification and would
+prevent a single resource URI from being tested over multiple transports.
+
+## Protocol History
+
+MoQT drafts through 17 identify WebTransport servers with an HTTPS URI and
+native QUIC servers with an `moqt` URI. The working group unified these in
+[moq-transport PR #1486](https://github.com/moq-wg/moq-transport/pull/1486),
+following discussion in
+[issue #268](https://github.com/moq-wg/moq-transport/issues/268#issuecomment-3879776434)
+and at IETF 125.
+
+[MoQT draft 20, Section 3.1](https://www.ietf.org/archive/id/draft-ietf-moq-transport-20.html#section-3.1)
+uses `moqt://` for both native QUIC and WebTransport. On a QUIC connection, a
+client can offer version-specific MoQT ALPNs and `h3`; the selected ALPN
+determines whether the session uses native QUIC or WebTransport over HTTP/3.
+For WebTransport, the client derives an HTTPS URI by replacing the `moqt`
+scheme and negotiates the MoQT protocol using `WT-Available-Protocols` and
+`WT-Protocol`. A client can also establish WebTransport over HTTP/2 and
+TLS/TCP.
+
+Version selection is a separate dimension. Since draft 15, native QUIC uses a
+version-specific `moqt-NN` ALPN and WebTransport uses the same identifier in
+its application protocol negotiation. Earlier drafts use ALPN `moq-00` and
+negotiate a version in SETUP.
+
+## Decision
+
+The target interface separates three concepts:
+
+1. **Resource identity:** one canonical `moqt://` URI for draft 18 and later.
+2. **Requested transport constraint:** an explicit runner-to-client input,
+   initially `auto`, `quic`, or `webtransport`.
+3. **Observed result:** TAP metadata records the transport stack and protocol
+   identifiers actually selected.
+
+`https://` remains accepted as a legacy WebTransport locator while registered
+clients need it. It does not become the permanent way to force WebTransport
+for draft 18 and later. The explicit transport constraint will perform that
+job without changing the resource identity.
+
+## Migration Plan
+
+### Phase 1: Document the boundary
+
+- Preserve current runner behavior and registered endpoint URLs.
+- Describe `https://` as current compatibility behavior, not current MoQT URI
+  semantics.
+- Encourage new draft 18 and later integrations to register `moqt://` URIs.
+- Record actual protocol and transport negotiation in optional TAP metadata.
+
+### Phase 2: Add an explicit client constraint
+
+- Add a runner-to-client environment variable for `auto`, `quic`, or
+  `webtransport`; settle its final name in the implementation change.
+- In `auto` mode, a draft 18 and later client can offer both native MoQT and
+  HTTP ALPNs in preference order as specified by MoQT.
+- In constrained modes, the client narrows what it offers. The URI remains
+  `moqt://`.
+- Keep the runner's existing endpoint `transport` value as the requested and
+  expected transport for a forced run. It must not be treated as proof of what
+  was negotiated.
+
+### Phase 3: Adapt lagging clients
+
+- Pass the canonical URI and requested constraint directly to clients that
+  support the new interface.
+- Let per-implementation adapters translate a constrained WebTransport run to
+  an `https://` locator when a legacy client still selects transport by scheme.
+- Keep existing `https://` registry entries until the corresponding client and
+  endpoint have been verified with `moqt://` plus an explicit constraint.
+
+### Phase 4: Retire compatibility behavior
+
+- Migrate an endpoint only after its client succeeds over every registered
+  transport using the canonical URI and reports the selected stack.
+- Remove scheme translation per implementation rather than on a global date.
+- Stop accepting `https://` as a MoQT relay locator after no active registered
+  implementation requires it. It remains the internally derived URI used by a
+  WebTransport handshake.
+
+## QMux
+
+QMux broadens the transport matrix but does not change the separation above.
+[QMux draft 02](https://www.ietf.org/archive/id/draft-ietf-quic-qmux-02.html)
+requires an application mapping over TLS to assign an ALPN distinct from that
+application's native QUIC ALPN. The
+[QMux over WebSocket draft 00](https://www.ietf.org/archive/id/draft-lcurley-qmux-websocket-00.html)
+instead carries the application's native QUIC identifier in
+`Sec-WebSocket-Protocol`.
+
+The expired
+[MOQT over QMux draft 00](https://www.ietf.org/archive/id/draft-nandakumar-moq-qmux-moqt-00.html)
+proposes a MoQT mapping over QMux/TLS/TCP, including direct stream mapping and
+reuse of the native `moqt-NN` ALPN. However, that proposal references the
+earlier `draft-opik-quic-qmux-00`; its ALPN choice does not satisfy QMux draft
+02's newer requirement for a mapping-specific identifier. It also does not
+define a QMux-over-WebSocket mapping. The proposal is therefore part of the
+implementation picture, but no MoQT-over-QMux identifier aligned with the
+current QMux draft is standardized yet. The runner can name observed stacks
+without predicting how that mismatch will be resolved.
+
+## Consequences
+
+- Current implementations continue to work during migration.
+- A transport-filtered run becomes an explicit test condition rather than an
+  inference from URL syntax.
+- The same MOQT resource can be tested over native QUIC and WebTransport.
+- Reports distinguish requested constraints from observed negotiation.
+- Implementing the new constraint requires coordinated runner, adapter, and
+  client changes; this decision does not implement them.

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -1,0 +1,160 @@
+# Test Catalog And Contribution Process
+
+This directory catalogs MoQT interoperability tests. The framework primarily
+supports the IETF MoQ working group's efforts to demonstrate interoperability
+between independent implementations and independently implemented protocol
+features. Results inform that work rather than formally certifying an
+implementation. Implementors may also use them as one signal when validating
+their work or run some tests in their own CI.
+
+## Current Test Inventory
+
+Some tests in the suite predate the lifecycle labels below. They can be labeled
+as participants revisit them; adding a label does not change their behavior.
+
+| Identifier | Area | Specification |
+|------------|------|---------------|
+| `setup-only` | Session establishment | [TEST-CASES.md](./TEST-CASES.md#setup-only) |
+| `announce-only` | Namespace discovery | [TEST-CASES.md](./TEST-CASES.md#announce-only) |
+| `publish-namespace-done` | Namespace discovery | [TEST-CASES.md](./TEST-CASES.md#publish-namespace-done) |
+| `subscribe-error` | Subscription | [TEST-CASES.md](./TEST-CASES.md#subscribe-error) |
+| `rendezvous-timeout` | Subscription | [TEST-CASES.md](./TEST-CASES.md#rendezvous-timeout) |
+| `announce-subscribe` | Subscription | [TEST-CASES.md](./TEST-CASES.md#announce-subscribe) |
+| `subscribe-before-announce` | Subscription | [TEST-CASES.md](./TEST-CASES.md#subscribe-before-announce) |
+
+## Specification Layout
+
+`TEST-CASES.md` remains the reference for existing tests. New tests may use one
+prose file per identifier under an area directory, such as
+`data-plane/data-subgroup-basic.md`. Area README files define only mechanics
+shared by tests in that area.
+
+A test specification should make it possible for another implementation to
+reproduce the scenario. It will usually state:
+
+- its stable identifier, lifecycle status, and
+  [test specification revision](#test-specification-revisions);
+- applicable protocol drafts and normative references;
+- required roles, preconditions, and controlled procedure;
+- observable success criteria and permitted variation;
+- timeout behavior and useful diagnostics;
+- core level or profile membership, when applicable.
+
+The prose specification is normative. Examples, implementation source, and TAP
+YAML diagnostics can illustrate or report the test, but do not define it.
+
+## Proposing A Test
+
+A test may begin with an implementation, an issue, or a PR. Implementors are
+encouraged to document useful tests here so that others can understand,
+discuss, and independently implement the same scenario. Early proposals are
+also welcome when writing down a scenario would help clarify protocol text or
+an interoperability question.
+
+Tests may cover the core MoQT specification or extension drafts. In either
+case, the specification should identify the interoperability property, relevant
+protocol text, and observable behavior. It may leave details open while they
+are being discussed. As a test sees wider use, its specification should converge
+on an unambiguous procedure and expected behavior that independent
+implementations can reproduce.
+
+## Test Lifecycle
+
+The labels below organize the catalog and communicate where a test stands from
+early proposal through broad adoption. As of September 2026, they do not
+determine which tests the runner executes: it runs every test exposed by each
+participating client. Implementors can take advantage of that behavior to try
+anything they are curious about, whether or not it is cataloged here yet.
+
+### Proposal
+
+A proposal is a test idea that would benefit from discussion or broader
+implementation. It may describe a scenario before anyone implements it, or it
+may document a test that one implementation already exposes. Proposals can be
+listed in area indexes to make that work visible and invite collaboration.
+
+### Candidate
+
+A candidate has a sufficiently clear prose specification for other
+implementations to try. It will commonly describe a test already exposed by at
+least one implementation, but a well-understood unimplemented scenario may
+also be useful as a candidate. Results and implementation experience can then
+improve the procedure, account for permitted variation, and distinguish the
+intended property from setup or harness problems.
+
+The candidate label makes promising shared work easier to find.
+
+### Standard
+
+A standard test recognizes a scenario that already has broad support across
+diverse, independently maintained implementations. The designation helps
+participants find scenarios that have proven useful for comparison over time.
+
+Broad independent implementation is the primary signal for this label. As that
+experience accumulates, the shared specification should also make clear that:
+
+- the behavior is grounded in the applicable protocol specification;
+- independently maintained implementations can execute the same procedure;
+- results are reproducible across relevant clients, relays, and environments;
+- failures distinguish the intended property from setup or harness problems;
+- remaining permitted implementation variation is documented.
+
+The label has no special execution behavior today. As the suite grows, standard
+tests could form a bounded, regularly run set that covers essential MoQT
+behavior without crowding the nightly report with every proposal and candidate.
+
+### Retired
+
+A retired test remains documented so that historical results can be
+interpreted, but is no longer suggested for new comparisons. This will most
+often happen when a test no longer applies to recent MoQT drafts or when a newer
+test covers the same behavior more clearly. Its specification explains the
+reason and points to any replacement. Existing result history is not rewritten.
+
+## Support Levels And Profiles
+
+Levels and profiles are a provisional experiment inspired by interoperability
+discussions at IETF 126 in Vienna. They are intended to help organize expanding
+test coverage, and feedback on the approach is welcome.
+
+Core support levels are cumulative collections of standard tests. A coverage
+summary could say that a client covers level N when it exposes every test in
+that level and every lower level. Individual pass, fail, skip, and unsupported
+outcomes remain separate; coverage does not imply that every test passed. The
+contents of each level will be recorded here as the experiment develops.
+
+Coverage is based on explicit evidence, such as an implementation opting into
+`--list` discovery or reporting a test result. If a client does not report a
+test, its support is unknown rather than unsupported.
+
+Profiles group capabilities that are useful but do not fit a universal
+progression, such as datagrams or rendezvous behavior. Reports may summarize
+profile coverage independently of core levels while continuing to show each
+observed outcome.
+
+Levels and profiles offer an informational view of coverage rather than a claim
+of total MoQT conformance.
+
+## Test Specification Revisions
+
+Each new test specification starts at revision 1. The revision is scoped to its
+stable test identifier and increases when a change could alter whether an
+unchanged implementation passes or fails. This includes changes to the
+procedure, wire stimulus, required observations, timeout or completion
+behavior, and permitted variation.
+
+Editorial changes, corrected references, lifecycle labels, diagnostics, and
+examples that do not alter required behavior keep the current revision. A
+materially different interoperability property should use a new test identifier
+instead of a new revision. Revisions are never reused or reset.
+
+A client that reports [`test_spec_revision`](../TAP-YAML-METADATA.md#common-fields)
+reports the revision it implemented, which may be older than the latest one in
+this repository. An omitted revision is unknown; it is not assumed to be 1.
+
+## Adding Or Changing A Test
+
+Share whatever context is available: the protocol property being explored,
+implementation experience, known unsupported cases, or open questions. If
+experience is still thin, writing the test down is a good way to invite
+collaboration.

--- a/docs/tests/TEST-CASES.md
+++ b/docs/tests/TEST-CASES.md
@@ -1,6 +1,9 @@
 # MoQT Interoperability Test Cases
 
-> **This is the reference specification for test cases.** To propose new test cases, open a PR against this file. To implement these tests in your MoQT stack, see [IMPLEMENTING-A-TEST-CLIENT.md](../IMPLEMENTING-A-TEST-CLIENT.md).
+> **This is the reference specification for the tests listed below.** The
+> [test catalog and contribution process](./README.md) explains how to add more.
+> To implement these tests in your MoQT stack, see
+> [IMPLEMENTING-A-TEST-CLIENT.md](../IMPLEMENTING-A-TEST-CLIENT.md).
 
 This document defines interoperability test cases for Media over QUIC Transport (MoQT). These specifications are designed to be implementation-neutral and precise enough that any MoQT implementation can build a compatible test client.
 
@@ -16,7 +19,8 @@ Each test case follows this structure:
 - **Protocol References**: Relevant MoQT draft sections
 - **Procedure**: Step-by-step behavior
 - **Success Criteria**: What constitutes a pass
-- **Diagnostic Roles**: For multi-connection tests, the named roles for connection ID reporting (see [Connection ID Conventions](../TEST-CLIENT-INTERFACE.md#connection-id-conventions))
+- **Diagnostic Roles**: Stable role names used under `sessions` in
+  [YAML diagnostics](../TAP-YAML-METADATA.md#session-fields)
 - **mlog Events**: Suggested qlog/mlog events for validation (optional)
 
 ---
@@ -41,6 +45,8 @@ Each test case follows this structure:
 
 **Timeout**: 2 seconds
 
+**Diagnostic Roles**: `client`
+
 **mlog Events** (relay-side, suggested):
 
 ```json
@@ -50,7 +56,7 @@ Each test case follows this structure:
 
 ---
 
-## Category: Namespace Publishing
+## Category: Namespace Discovery
 
 ### `announce-only`
 
@@ -71,6 +77,8 @@ Each test case follows this structure:
 - No error response
 
 **Timeout**: 2 seconds after sending PUBLISH_NAMESPACE
+
+**Diagnostic Roles**: `publisher`
 
 **mlog Events** (relay-side, suggested):
 
@@ -103,6 +111,8 @@ Each test case follows this structure:
 
 **Timeout**: 2 seconds after sending PUBLISH_NAMESPACE
 
+**Diagnostic Roles**: `publisher`
+
 ---
 
 ## Category: Subscriptions
@@ -127,6 +137,8 @@ Each test case follows this structure:
 - Exit code 0 (the error was expected and correctly handled)
 
 **Timeout**: 2 seconds
+
+**Diagnostic Roles**: `subscriber`
 
 **mlog Events** (relay-side, suggested):
 
@@ -161,6 +173,8 @@ A relay may use a shorter timeout than requested, so the test does not impose a 
 
 **Timeout**: 2 seconds
 
+**Diagnostic Roles**: `subscriber`
+
 ---
 
 ### `announce-subscribe`
@@ -193,7 +207,8 @@ A relay may use a shorter timeout than requested, so the test does not impose a 
 
 **Timeout**: 3 seconds total
 
-**Diagnostic Roles**: `publisher`, `subscriber` — report as `publisher_connection_id` and `subscriber_connection_id` in YAML diagnostics
+**Diagnostic Roles**: `publisher`, `subscriber` - use these names under
+`sessions` in [YAML diagnostics](../TAP-YAML-METADATA.md#session-fields)
 
 ---
 
@@ -227,13 +242,17 @@ Either outcome is valid; the test checks for graceful handling.
 
 **Timeout**: 3.5 seconds total
 
-**Diagnostic Roles**: `publisher`, `subscriber` — report as `publisher_connection_id` and `subscriber_connection_id` in YAML diagnostics (regardless of connection order)
+**Diagnostic Roles**: `publisher`, `subscriber` - use these names under
+`sessions` in [YAML diagnostics](../TAP-YAML-METADATA.md#session-fields),
+regardless of connection order
 
 ---
 
 ## Future Test Cases
 
-This section outlines potential future test cases. The actual test definitions will be added as implementations mature and working group consensus develops.
+This section collects early ideas that do not yet have complete test
+specifications. They can be developed as implementations and discussion make
+the expected behavior clearer.
 
 ### Data Flow Tests
 
@@ -251,18 +270,16 @@ Different use cases may require different message flow patterns:
 - **PUBLISH_NAMESPACE + SUBSCRIBE flow**: Publisher announces availability, subscriber requests specific track
 - **SUBSCRIBE_NAMESPACE + PUBLISH flow**: Subscriber expresses interest in namespace prefix, publisher sends tracks
 
-As moq-rs and other implementations add support for both patterns, we should develop test cases that exercise each.
+### Test Client Capability Discovery
 
-### Test Client Capability Matrix
+Test clients may implement the [`--list` interface](../TEST-CLIENT-INTERFACE.md#list-output)
+to report the identifiers they support. Clients remain compatible without this
+interface. When neither `--list` nor a test result provides an explicit signal,
+support is unknown rather than unsupported.
 
-As the test suite grows, different test clients may support different subsets of tests. A capability matrix could help:
-
-| Test Client | `setup-only` | `announce-only` | `publish-namespace-done` | `subscribe-error` | `announce-subscribe` | `subscribe-before-announce` |
-|-------------|--------------|-----------------|--------------------------|-------------------|----------------------|-----------------------------|
-| moq-test-client (moq-rs) | Yes | Yes | Yes | Yes | Yes | Yes |
-| implementation-b | Yes | Yes | No | Yes | No | No |
-
-The mechanism for declaring and discovering these capabilities is TBD - potentially via a `--list` command that outputs supported test identifiers.
+This signal may eventually support things like the coverage summaries described
+in the [test catalog](./README.md#support-levels-and-profiles). As of September
+2026, the runner does not derive support levels or profiles from it.
 
 ---
 

--- a/implementations.schema.json
+++ b/implementations.schema.json
@@ -156,7 +156,7 @@
         "transport": {
           "type": "string",
           "enum": ["quic", "webtransport"],
-          "description": "Transport type: 'quic' (raw QUIC, moqt://) or 'webtransport' (HTTP/3, https://)"
+          "description": "Intended transport independent of URL scheme: 'quic' or 'webtransport'"
         },
         "status": {
           "type": "string",


### PR DESCRIPTION
## Summary

- document an optional TAP YAML vocabulary for negotiated versions, transport stacks, session identifiers, durations, and failure context
- add a single test catalog with Candidate, Standard, and Retired lifecycle states
- describe cumulative coverage levels and orthogonal capability profiles without turning them into execution gates
- document the transition from scheme-selected transport to canonical `moqt://` URIs with an independent transport constraint

Existing clients can continue emitting plain TAP. Missing or unknown metadata remains unknown rather than unsupported, and this change does not alter runner execution or report generation.

This replaces the fixture-heavy data-plane proposal previously on this branch. It does not add data-plane scenarios or test-client implementation requirements. Those can follow as separate, independently reviewable changes after the reporting and catalog groundwork is in place.

## Validation

- `bash lib/test/test-tap-parser.sh` (40/40)
- `python3 -m json.tool implementations.schema.json`
- `git diff --check`
- documentation links, anchors, and TAP YAML examples reviewed
