### PR TITLE
moq-go: advertise draft-20 (moqt-20 ALPN)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -162,7 +162,7 @@ jobs:
               ;;
             moq-go)
               REF="${{ inputs.ref }}"
-              REF="${REF:-draft-19}"
+              REF="${REF:-draft-20}"
               echo "build_type=build" >> "$GITHUB_OUTPUT"
               echo "ref=$REF" >> "$GITHUB_OUTPUT"
               echo "build_command=./builds/moq-go/build.sh --ref $REF" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Filter a single relay: `make interop-remote RELAY=moxygen`. See [Getting Started
 | MOQtail | OzU | 16 | relay | `https://relay.moqtail.dev` |
 | libquicr | Cisco | 14 | relay | `https://us-west-2.relay.quicr.org:33437/relay` |
 | imquic | Meetecho | 16-18 | relay, client | `https://lminiero.it:9000` |
-| moq-go | Vsevolod Strukchinsky | 19 | relay, client |  |
+| moq-go | Vsevolod Strukchinsky | 20 | relay, client |  |
 | moqtopus | Kota Yatagai | 18 | client |  |
 | xquic | Alibaba | 14, 18 | relay, client |  |
 

--- a/builds/moq-go/build.sh
+++ b/builds/moq-go/build.sh
@@ -2,7 +2,7 @@
 # build.sh - Build moq-go Docker images from source
 #
 # Usage:
-#   ./build.sh                       # Clone from default ref (draft-19)
+#   ./build.sh                       # Clone from default ref (draft-20)
 #   ./build.sh --ref feature-branch  # Clone specific branch/tag/commit
 #   ./build.sh --repo URL            # Clone from a different repository (fork)
 #   ./build.sh --local ~/moq-go      # Use local checkout
@@ -24,7 +24,7 @@ set -euo pipefail
 
 IMPL_NAME="moq-go"
 REPO_URL="https://github.com/floatdrop/moq-go"
-DEFAULT_REF="draft-19"
+DEFAULT_REF="draft-20"
 
 # Build directory (where this script lives)
 BUILD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/builds/moq-go/config.json
+++ b/builds/moq-go/config.json
@@ -1,8 +1,8 @@
 {
   "name": "moq-go",
-  "description": "Go implementation of MoQT (draft-19): session library, reference relay, and interop test client",
+  "description": "Go implementation of MoQT (draft-20): session library, reference relay, and interop test client",
   "repository": "https://github.com/floatdrop/moq-go",
-  "default_ref": "draft-19",
+  "default_ref": "draft-20",
   "targets": {
     "relay": {
       "dockerfile": ".sources/moq-go/cmd/relay/Dockerfile",

--- a/implementations.json
+++ b/implementations.json
@@ -200,9 +200,9 @@
       "organization": "floatdrop",
       "repository": "https://github.com/floatdrop/moq-go",
       "draft_versions": [
-        "draft-19"
+        "draft-20"
       ],
-      "notes": "Go implementation of MoQT (draft-ietf-moq-transport-19): transport-agnostic session library, single-instance reference relay, and an interop test client. Advertises the moqt-19 ALPN only. Both relay and client images are built in-tree (cmd/relay, cmd/interop-client) and follow the runner conventions.",
+      "notes": "Go implementation of MoQT (draft-ietf-moq-transport-20): transport-agnostic session library, single-instance reference relay, and an interop test client. Advertises the moqt-20 ALPN only. Both relay and client images are built in-tree (cmd/relay, cmd/interop-client) and follow the runner conventions.",
       "roles": {
         "relay": {
           "docker": {


### PR DESCRIPTION
Bump the moq-go registration from draft-19 to draft-20 to match the upstream draft-20 branch, which now advertises the moqt-20 ALPN only. This is an in-place move rather than additive, since the image negotiates draft-20 only.

- implementations.json: draft_versions -> [draft-20], notes
- builds/moq-go/config.json: default_ref + description -> draft-20
- builds/moq-go/build.sh: DEFAULT_REF -> draft-20
- README.md: table row -> 20
- .github/workflows/build-images.yml: CI default REF -> draft-20

Verified locally with `make build-impl IMPL=moq-go` — both `moq-go-relay:latest` and `moq-go-client:latest` build from draft-20 (17c8493).

🤖 Generated with [Claude Code](https://claude.com/claude-code)