### PR TITLE
moqlivemock: add the mlmrel relay role

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -326,8 +326,15 @@
       "draft_versions": [
         "draft-18"
       ],
-      "notes": "Go implementation, draft-18 only. Test client and live CMAF publisher. Publisher announces the moq-test/interop namespace for interop testing.",
+      "notes": "Go implementation, draft-18 only. Test client, relay and live CMAF publisher. Publisher announces the moq-test/interop namespace for interop testing.",
       "roles": {
+        "relay": {
+          "docker": {
+            "image": "ghcr.io/eyevinn/mlmrel:latest",
+            "url": "moqt://relay:4443",
+            "notes": "mlmrel, published from Eyevinn/moqlivemock CI. Serves raw QUIC and WebTransport (/moq) on one port; registered with a moqt:// URL because mlmtest dials raw QUIC."
+          }
+        },
         "client": {
           "docker": {
             "image": "ghcr.io/eyevinn/mlmtest:latest",


### PR DESCRIPTION
Adds a `relay` role to the existing `moqlivemock` entry: `ghcr.io/eyevinn/mlmrel:latest`, published from Eyevinn/moqlivemock CI, MoQT draft-18. Same `draft_versions` as the client, so no new key.

### Why `moqt://relay:4443`

mlmrel serves raw QUIC and WebTransport (`/moq`) on one port, but `mlmtest` dials raw QUIC only, so the docker URL is `moqt://` like `xquic-draft-18` and `aiomoqt-relay-quic`. A second entry with an `https://relay:4443/moq` URL can follow for WebTransport-only clients.

### Verified locally against the published image

`make test RELAY_IMAGE=ghcr.io/eyevinn/mlmrel:latest CLIENT_IMAGE=ghcr.io/eyevinn/mlmtest:latest`, with the URL resolved from this registration:

```
ok 1 - setup-only             ok 4 - subscribe-error
ok 2 - announce-only          ok 5 - announce-subscribe
ok 3 - publish-namespace-done ok 6 - subscribe-before-announce
```

`./run-interop-tests.sh --relay moqlivemock --docker-only` against all twelve registered draft-18 clients (image revision `82775e6`): eight pass — aiomoqt, imquic, moq-dev-rs, moqlivemock, stitcher-moq, xquic-draft-18, moq5, moqtopus. The four failures are on the client side:

- moq-dev-js fails all six cases at once; it needs a WebTransport URL, and fails the same way against `aiomoqt-relay-quic` in the nightly.
- moq-rs-draft-18 passes the six runner cases and fails only its own two extra PUBLISH cases, which moqtransport does not implement yet.
- moxygen and moqx fail `announce-subscribe` because their SUBSCRIBE carries SUBSCRIPTION_FILTER type 250 (`LocationType::LargestGroup`), which draft-18 does not define; the relay answers REQUEST_ERROR NOT_SUPPORTED with the reason.

The first run of this matrix turned up two relay behaviors that left a subscriber waiting for its own timeout instead of getting an answer — a SUBSCRIBE the relay could not accept went unanswered, and a forwarded SUBSCRIBE the upstream never answered hung — and a hold on every SUBSCRIBE that contradicted draft-18 §10.2.6 (one without RENDEZVOUS_TIMEOUT now gets an immediate DOES_NOT_EXIST; one with it is held for the asked time). All three are fixed in the published image (Eyevinn/moqlivemock#138 and #139, on moqtransport v0.13.0).

`validate-registration.sh`: schema valid, image found.
