### PR TITLE
spec: define rendezvous timeout test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,7 @@ Test cases are defined in `docs/tests/TEST-CASES.md`. Current tests:
 | `announce-only` | Namespace | PUBLISH_NAMESPACE flow |
 | `publish-namespace-done` | Namespace | Unpublish namespace |
 | `subscribe-error` | Subscription | Error for non-existent track |
+| `rendezvous-timeout` | Subscription | Timeout waiting for a publisher |
 | `announce-subscribe` | Subscription | Publisher announces, subscriber subscribes |
 | `subscribe-before-announce` | Subscription | Out-of-order subscribe/announce |
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Tests are organized by functional category:
 | `announce-only` | Namespace | Announce namespace, receive OK, close |
 | `publish-namespace-done` | Namespace | Announce, then send PUBLISH_NAMESPACE_DONE |
 | `subscribe-error` | Subscription | Subscribe to non-existent track, expect error |
+| `rendezvous-timeout` | Subscription | Subscribe with a rendezvous window, expect TIMEOUT |
 | `announce-subscribe` | Subscription | Publisher announces, subscriber subscribes |
 | `subscribe-before-announce` | Subscription | Subscribe before publisher announces |
 

--- a/docs/TEST-CLIENT-INTERFACE.md
+++ b/docs/TEST-CLIENT-INTERFACE.md
@@ -213,6 +213,7 @@ setup-only
 announce-only
 publish-namespace-done
 subscribe-error
+rendezvous-timeout
 announce-subscribe
 subscribe-before-announce
 ```

--- a/docs/TEST-SPECIFICATIONS.md
+++ b/docs/TEST-SPECIFICATIONS.md
@@ -18,6 +18,7 @@ This document has been reorganized into separate, focused documents:
 | `announce-only` | Namespace | PUBLISH_NAMESPACE flow |
 | `publish-namespace-done` | Namespace | Unpublish namespace |
 | `subscribe-error` | Subscription | Error for non-existent track |
+| `rendezvous-timeout` | Subscription | Timeout waiting for a publisher |
 | `announce-subscribe` | Subscription | Relay routes subscription to publisher |
 | `subscribe-before-announce` | Subscription | Out-of-order subscribe/announce |
 

--- a/docs/tests/TEST-CASES.md
+++ b/docs/tests/TEST-CASES.md
@@ -137,6 +137,32 @@ Each test case follows this structure:
 
 ---
 
+### `rendezvous-timeout`
+
+**Protocol References**: MoQT-18 §5.1 (Subscriptions), §10.2.6 (RENDEZVOUS_TIMEOUT), §10.6 (REQUEST_ERROR)
+
+**Procedure**:
+
+1. Connect and complete SETUP exchange
+2. Send SUBSCRIBE for test namespace/track with RENDEZVOUS_TIMEOUT set to 500 milliseconds
+3. Expect REQUEST_ERROR response
+4. Close connection gracefully
+
+**Test Namespace**: `nonexistent/rendezvous`
+
+**Test Track**: `test-track`
+
+**Success Criteria**:
+
+- REQUEST_ERROR received with error code TIMEOUT
+- Exit code 0 (the timeout was expected and correctly handled)
+
+A relay may use a shorter timeout than requested, so the test does not impose a minimum wait.
+
+**Timeout**: 2 seconds
+
+---
+
 ### `announce-subscribe`
 
 **Protocol References**: MoQT-18 §5.1 (Subscriptions), §6.2 (Publishing Namespaces), §10.7-10.8 (SUBSCRIBE/SUBSCRIBE_OK), §10.15 (PUBLISH_NAMESPACE), §10.5 (REQUEST_OK / `PUBLISH_NAMESPACE_OK` alias)


### PR DESCRIPTION
Define a draft-18 interoperability test for RENDEZVOUS_TIMEOUT. The test requires REQUEST_ERROR TIMEOUT when no publisher appears during a requested 500 ms rendezvous window.