### PR TITLE
use moqt:// for webtransport endpoint

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -411,7 +411,7 @@
               "notes": "Raw QUIC endpoint"
             },
             {
-              "url": "https://moqt.nokiaresearch.com:4443/moq",
+              "url": "moqt://moqt.nokiaresearch.com:4443/moq",
               "transport": "webtransport",
               "tls_disable_verify": false,
               "notes": "WebTransport endpoint"

--- a/implementations.json
+++ b/implementations.json
@@ -399,7 +399,7 @@
       "name": "moqt-nokiaresearch",
       "organization": "Nokia",
       "repository": "",
-      "draft_versions": ["draft-18"],
+      "draft_versions": ["draft-18","draft-19"],
       "notes": "Support native QUIC and WebTransport",
       "roles": {
         "relay": {


### PR DESCRIPTION
* the "moqtopus" requires "moqt://" than "https" for webtransport tests.
* added "moqt-19"