### PR TITLE
stitcher-moq: declare draft-20 support

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -555,9 +555,10 @@
         "draft-16",
         "draft-17",
         "draft-18",
-        "draft-19"
+        "draft-19",
+        "draft-20"
       ],
-      "notes": "Stock moq-dev moq-relay (v0.14.12+) fronting Paramount's MoQ SSAI sandbox on GCP. Anonymous subscribe; anonymous publish scoped to the moq-test and moq-test-00 prefixes. Single UDP+TCP 443 via L4 passthrough LB, ACME certificate. Publishes live demo channels 24/7. The client target is a test client on the current crates.io moq-net/moq-native (0.19.x) implementing all six cases, including subscribe-error and subscribe-before-announce.",
+      "notes": "Stock moq-dev moq-relay (v0.14.15) fronting Paramount's MoQ SSAI sandbox on GCP. Anonymous subscribe; anonymous publish scoped to the moq-test and moq-test-00 prefixes. Single UDP+TCP 443 via L4 passthrough LB, ACME certificate. Publishes live demo channels 24/7. The client target is a test client on the current crates.io moq-net/moq-native (0.19.x) implementing all six cases, including subscribe-error and subscribe-before-announce.",
       "roles": {
         "relay": {
           "remote": [


### PR DESCRIPTION
The WG picked **draft-20 as the Seattle interop target** at the 2026-09-08 interim, so adding it to the Paramount `stitcher-moq` relay entry.

The relay is stock moq-dev, now bumped to the `#3311` release (moq-relay 0.14.15 / moq-net 0.2.18 / moq-native 0.19.16), which carries moq-transport draft-20 via moq-dev#3255. Notes updated from `v0.14.12+` to the pinned `0.14.15`.

**Verified live before opening this**, against the endpoint already in the file (`moqt://34-72-6-160.sslip.io:443`):

```
connected version=Ietf(Draft20)
connected version=moq-transport-20
received subscribe_namespace SubscribeNamespace { namespace: Path("moq-test") }
received subscribe_namespace SubscribeNamespace { namespace: Path("moq-test-00") }
namespace broadcast=moq-test/vprobe.hang
```

So it negotiates draft-20 and exchanges namespace control messages on it, not just ALPN. draft-18 continues to negotiate unchanged. The same probe was a hard `peer doesn't support any known protocol` rejection before today's deploy — I held this PR until it wasn't.

No other entries touched.