### PR TITLE
Register quic-zig (client and relay)

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -679,6 +679,25 @@
           }
         }
       }
+    },
+    "quic-zig": {
+      "name": "quic-zig",
+      "organization": "Endel Dreyer",
+      "repository": "https://github.com/endel/quic-zig",
+      "draft_versions": ["draft-17", "draft-18"],
+      "notes": "QUIC, HTTP/3, WebTransport and MoQ from scratch in Zig. The relay is WebTransport; the client speaks both transports and selects its draft with --draft.",
+      "roles": {
+        "client": {
+          "docker": {
+            "image": "ghcr.io/endel/quic-zig-moq-client:latest"
+          }
+        },
+        "relay": {
+          "docker": {
+            "image": "ghcr.io/endel/quic-zig-moq-relay:latest"
+          }
+        }
+      }
     }
   },
   "_comment_how_to_add": [


### PR DESCRIPTION
Registers [quic-zig](https://github.com/endel/quic-zig) as a client and a relay.

QUIC, HTTP/3, WebTransport and MoQ written from scratch in Zig, no external
protocol libraries. draft-17 and draft-18 are both implemented; the draft
travels with each message, read off the ALPN a peer negotiated, so the relay
serves clients at whichever they asked for.

Both images publish to GHCR on every push to `main` and pull anonymously:
`ghcr.io/endel/quic-zig-moq-client` and `ghcr.io/endel/quic-zig-moq-relay`.
They follow the conventions in IMPLEMENTATIONS.md (`/certs/cert.pem`,
`/certs/priv.key`, `MOQT_ROLE`, `MOQT_PORT`, uid 1000, `/mlog`), so no adapter
is needed. `./validate-registration.sh --impl quic-zig` passes.

### As a relay, `--relay quic-zig --docker-only`

| client | result | |
|---|---|---|
| moq-rs draft-18 | 9/9 | |
| moq-dev-rs | 6/6 | |
| moxygen | 5/6 | see below |
| imquic | 0/1 | see below |
| moqlivemock | 0/6 | see below |

Two rows are worth explaining up front rather than leaving them to be found:

**moxygen — `announce-subscribe` fails.** Its interop client sends
subscription filter type `250`, moxygen's private `LocationType::LargestGroup`.
draft-18 §5.1.2 defines `0x1`–`0x4` and requires PROTOCOL_VIOLATION for
anything else, so we close the session, which is what moq-dev-rs's relay does
too. Already reported as
[facebookexperimental/moxygen#225](https://github.com/facebookexperimental/moxygen/issues/225).

That issue's second half applies to this runner: `subscribe-error` and
`subscribe-before-announce` count a session close as the expected request
error, so they pass against us on a SUBSCRIBE we never parsed. Our honest
moxygen score is 3/6, not 5/6. Happy to open a separate issue about tightening
those two cases to require a protocol-level `REQUEST_ERROR` if that would be
useful.

**imquic and moqlivemock — every case fails at the handshake.** Both test
clients dial raw QUIC whatever the URL scheme says — imquic offers ALPN
`moqt-19, moqt-18, moqt-17, moqt-16` and `mlmtest` offers `moqt-18` against
`https://relay:4443` — and our relay image is WebTransport, so the handshake
ends in `no_application_protocol`. We do have a raw-QUIC relay; it is a
separate binary today, and serving both ALPNs on one port is on our list. Not
asking for anything here, just flagging that these two rows are a transport
mismatch rather than a protocol failure.

### As a client, `--client quic-zig --remote-only`

7/7 on both transports against moq-rs-draft-18, moqt-nr and moxygen. Against
imquic, moqx, stitcher-moq, moqtail and `cdn.moq.dev` the only case that fails
is `rendezvous-timeout`: docs/tests/TEST-CASES.md asks for `REQUEST_ERROR` with
code `TIMEOUT`, and those relays answer `DOES_NOT_EXIST` (0x10) or `404`. We
check for `TIMEOUT` as written. If the intent is that either is acceptable,
say so and we will relax the check — we would rather ask than quietly widen it.

One unrelated note: `generate-certs.sh` is not portable to macOS. LibreSSL
3.3.6 emits explicit EC parameters for that invocation and rustls rejects them,
so every pairing fails with "invalid peer certificate" and it reads like the
implementation's bug. Adding `-pkeyopt ec_param_enc:named_curve` fixes it. I
can send that as its own PR if you want it.
